### PR TITLE
Fix broken link to Integrations Roadmap

### DIFF
--- a/kb/our-products/are-you-a-seller/getting-started-as-a-new-seller/seller-api-development-roadmap.mdx
+++ b/kb/our-products/are-you-a-seller/getting-started-as-a-new-seller/seller-api-development-roadmap.mdx
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Seller API Development Roadmap
 
-At TravelgateX, we believe in the power of collaboration and innovation. That's why we've introduced our [Seller API Development Roadmap](https://docs.travelgatex.com/integrations-roadmap/). This roadmap is dedicated to providing transparency, one of our core values, and helping you plan your product strategy effectively in order to have a clear view of our plans and progress, giving you the information you need to succeed.
+At TravelgateX, we believe in the power of collaboration and innovation. That's why we've introduced our [Seller API Development Roadmap](https://app.travelgate.com/network/roadmap). This roadmap is dedicated to providing transparency, one of our core values, and helping you plan your product strategy effectively in order to have a clear view of our plans and progress, giving you the information you need to succeed.
 
 
 ![seller_api_development_roadmap_1](https://storage.travelgate.com/kbase/seller_api_development_roadmap_1.jpg)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -168,7 +168,7 @@ export default function Home() {
                   <img src="https://stplaformwe.blob.core.windows.net/docs/home_join_community_c.svg" />
                   <h6>Integrations Roadmap</h6>
                   <p>Take a look at Travelgate’s Seller API Development Roadmap.</p>
-                  <p><a href="https://docs.travelgatex.com/integrations-roadmap/" target="_blank">More information <i className="fa-solid fa-chevron-right"></i></a></p>
+                  <p><a href="https://app.travelgate.com/network/roadmap" target="_blank">More information <i className="fa-solid fa-chevron-right"></i></a></p>
                 </div>
               </div>
             </div>

--- a/src/pages/kb.js
+++ b/src/pages/kb.js
@@ -154,7 +154,7 @@ export default function Home() {
                           <img src="https://stplaformwe.blob.core.windows.net/docs/home_join_community_c.svg" />
                           <h6>Integrations Roadmap</h6>
                           <p>Take a look at Travelgate’s Seller API Development Roadmap.</p>
-                          <p><a href="https://docs.travelgatex.com/integrations-roadmap/" target="_blank">More information <i class="fa-solid fa-chevron-right"></i></a></p>
+                          <p><a href="https://app.travelgate.com/network/roadmap" target="_blank">More information <i class="fa-solid fa-chevron-right"></i></a></p>
                         </div>
                       </div>
                     </div>

--- a/src/theme/Footer/Layout/index.js
+++ b/src/theme/Footer/Layout/index.js
@@ -16,7 +16,7 @@ export default function FooterLayout({style, links, logo, copyright}) {
             <h6>Company</h6>
             <ul>
               <li><a href="https://www.travelgate.com/" target="_blank">TravelgateX</a></li>
-              <li><a href="https://docs.travelgatex.com/integrations-roadmap/" target="_blank">Integrations Roadmap</a></li>
+              <li><a href="https://app.travelgate.com/network/roadmap" target="_blank">Integrations Roadmap</a></li>
               <li><a href="https://blog.travelgatex.com/en?hsLang=en" target="_blank">Blog</a></li>
               <li><a href="https://community.travelgatex.com/" target="_blank">TGX Community</a></li>
             </ul>


### PR DESCRIPTION
Fixes broken link to Integrations Roadmap.

From:

https://docs.travelgatex.com/integrations-roadmap/

To:

https://app.travelgate.com/network/roadmap