### PR TITLE
Fix(Docs): fixed place where static info retrieved

### DIFF
--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/category-list.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/category-list.mdx
@@ -81,7 +81,7 @@ Check the values you need to add in the [header](../making-requests/request-head
 
 ## CategoryList Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `CategoryList` request, the Seller will send you a corresponding `CategoryList` response.
+The response to the previous request is a list of categories from our database that corresponds to the supplier specified in the request.
 
 ```xml
 <CategoryListRS>

--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/currency-list.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/currency-list.mdx
@@ -82,7 +82,7 @@ Check the values you need to add in the [header](../making-requests/request-head
 
 ## CurrencyList Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `CurrencyList` request, the Seller will send you a corresponding `CurrencyList` response.
+The response to the previous request is a list of currencies from our database that corresponds to the supplier specified in the request.
 
 ```xml
 <CurrencyListRS>

--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/descriptive-info.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/descriptive-info.mdx
@@ -88,7 +88,7 @@ Check the values you need to add in the [header](../making-requests/request-head
 
 ## DescriptiveInfo Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `DescriptiveInfo` request, the Seller will send you a corresponding `DescriptiveInfo` response. There are two response options, **success** or **error**.
+The response to the previous request is a hotel from our database that corresponds to the supplier specified in the request.
 
 ### Success
 

--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/geographic-destination-tree.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/geographic-destination-tree.mdx
@@ -81,7 +81,7 @@ Check the values you need to add in the [header](../making-requests/request-head
 
 ## GeographicDestinationTree Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `GeographicDestinationTree` request, the Seller will send you a corresponding `GeographicDestinationTree` response.
+The response to the previous request is a list of destinations from our database that corresponds to the supplier specified in the request.
 
 ```xml
 <GeographicDestinationTreeRS>

--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/market-list.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/market-list.mdx
@@ -82,7 +82,7 @@ Check the values you need to add in the [header](../making-requests/request-head
 
 ## MarketList Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `MarketList` request, the Seller will send you a corresponding `MarketList` response.
+The response to the previous request is a list of markets from our database that corresponds to the supplier specified in the request.
 
 ```xml
 <MarketListRS>

--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/meal-plan-list.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/meal-plan-list.mdx
@@ -81,7 +81,7 @@ Check the values you need to add in the [header](../making-requests/request-head
 
 ## MealPlanList Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `MealPlanList` request, the Seller will send you a corresponding `MealPlanList` response.
+The response to the previous request is a list of mealplans from our database that corresponds to the supplier specified in the request.
 
 :::note
 

--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/meta-data.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/meta-data.mdx
@@ -82,7 +82,7 @@ Check the values you need to add in the [header](../making-requests/request-head
 
 ## MetaData Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `MetaData` request, the Seller will send you a corresponding `MetaData` response.
+The response to the previous request is a metadata from our database that corresponds to the supplier specified in the request.
 
 
 ```xml

--- a/docs/apis/for-buyers/legacy-pull-buyers-api/content/room-list.mdx
+++ b/docs/apis/for-buyers/legacy-pull-buyers-api/content/room-list.mdx
@@ -132,7 +132,7 @@ This token should be used as input in your next rooms list request, inside the `
 
 ## RoomList Response
 
-After each request, the Seller will have to process the data and provide a response. Upon receiving a `RoomList` request, the Seller will send you a corresponding `RoomList` response.
+The response to the previous request is a list of rooms from our database that corresponds to the supplier specified in the request.
 
 ```xml
 <RoomListRS>


### PR DESCRIPTION
ENGSUPPLY-10993

fixed information about retrieving static data in all content, api legacy pull buyer calls