### PR TITLE
feat: Update information of TimeSpan and DateTime fields 

### DIFF
--- a/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/bookcriteria.md
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/bookcriteria.md
@@ -7,8 +7,8 @@ Inherits from Criteria.
 
 | Name | Type | Description |
 |------|------|-------------|
-| **CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
+| **CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
+| **CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
 | **CheckInAsDateTime** | String | The check-in date parsed as a DateTime object. |
 | **CheckOutAsDateTime** | String | The check-out date parsed as a DateTime object. |
 | **TotalNights** | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/bookrq.md
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/bookrq.md
@@ -7,8 +7,8 @@ Represents a hotel booking request.
 | Name | Type | Description |
 |------|------|-------------|
 | **BookCriteria** | [BookCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/bookcriteria) | The booking criteria for the hotel reservation. |
-| **BookCriteria/CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **BookCriteria/CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
+| **BookCriteria/CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
+| **BookCriteria/CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
 | **BookCriteria/CheckInAsDateTime** | String | The check-in date parsed as a DateTime object. |
 | **BookCriteria/**<br />**CheckOutAsDateTime** | String | The check-out date parsed as a DateTime object. |
 | **BookCriteria/TotalNights** | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/quotecriteria.md
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/quotecriteria.md
@@ -6,8 +6,8 @@ Represents the criteria for a hotel Quote request. Inherits from Criteria.
 
 | Name | Type | Description |
 |------|------|-------------|
-| **CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
+| **CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
+| **CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
 | **CheckInAsDateTime** | String | The check-in date parsed as a DateTime object. |
 | **CheckOutAsDateTime** | String | The check-out date parsed as a DateTime object. |
 | **TotalNights** | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/quoterq.md
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/quoterq.md
@@ -7,8 +7,8 @@ Represents a request for a hotel Quote.
 | Name | Type | Description |
 |------|------|-------------|
 | **QuoteCriteria** | [QuoteCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/quotecriteria) | Criteria for the Quote request, such as dates, selected rooms, or other Search-related parameters. |
-| **QuoteCriteria/CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **QuoteCriteria/CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
+| **QuoteCriteria/CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
+| **QuoteCriteria/CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
 | **QuoteCriteria/**<br />**CheckInAsDateTime** | String | The check-in date parsed as a DateTime object. |
 | **QuoteCriteria/**<br />**CheckOutAsDateTime** | String | The check-out date parsed as a DateTime object. |
 | **QuoteCriteria/TotalNights** | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/searchcriteria.md
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/searchcriteria.md
@@ -7,8 +7,8 @@ Inherits from Criteria.
 
 | Name | Type | Description |
 |------|------|-------------|
-| **CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
+| **CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
+| **CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
 | **CheckInAsDateTime** | String | The check-in date parsed as a DateTime object. |
 | **CheckOutAsDateTime** | String | The check-out date parsed as a DateTime object. |
 | **TotalNights** | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/searchrq.md
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/searchrq.md
@@ -8,8 +8,8 @@ This class is used to define the parameters and settings for searching available
 | Name | Type | Description |
 |------|------|-------------|
 | **SearchCriteria** | [SearchCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/searchcriteria) | Gets the Search criteria for the hotel Search. |
-| **SearchCriteria/CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **SearchCriteria/CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
+| **SearchCriteria/CheckIn** | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
+| **SearchCriteria/CheckOut** | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
 | **SearchCriteria/**<br />**CheckInAsDateTime** | String | The check-in date parsed as a DateTime object. |
 | **SearchCriteria/**<br />**CheckOutAsDateTime** | String | The check-out date parsed as a DateTime object. |
 | **SearchCriteria/TotalNights** | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
@@ -943,14 +943,14 @@ The `Book` operation returns:
 |------|:--------:|:----:|-------------|
 | **AuditData** | 1 | [ProviderAudit](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/provideraudit) | Contains the requests and responses exchanged with the supplier.This field is populated internally by the connector framework. Integrators do not need to handle this field manually. |
 | **AuditData/Request** | 0 . . N | Array&lt;[ProviderAuditRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrq)&gt; | Collection of audit entries for provider requests.Each entry contains details about a specific request made to the provider. |
-| **AuditData/Request/SendAt** | 1 | String | The timestamp indicating when the request was sent. |
+| **AuditData/Request/SendAt** | 1 | String | The timestamp indicating when the request was sent. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Request/Data** | 1 | String | The payload data included in the request. |
 | **AuditData/Request/Url** | 1 | String | The URL of the provider endpoint to which the request is sent. |
 | **AuditData/Request/Headers** | 1 | Object | A collection of headers included in the request. |
 | **AuditData/Request/HttpMethod** | 1 | [HttpMethod](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/httpmethod) | The HTTP method used to send the request. |
 | **AuditData/Request/HttpMethod/**<br />**Method** | 1 | String |  No description available. |
 | **AuditData/Response** | 0 . . N | Array&lt;[ProviderAuditRs](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrs)&gt; | Collection of audit entries for provider responses.Each entry contains details about a specific response received from the provider. |
-| **AuditData/Response/ReceivedAt** | 1 | String | The timestamp indicating when the response was received. |
+| **AuditData/Response/ReceivedAt** | 1 | String | The timestamp indicating when the response was received. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Response/Data** | 1 | String | The payload data contained in the provider's response. |
 | **AuditData/Response/Headers** | 1 | Object | A collection of headers included in the provider's response. |
 | **AuditData/Response/StatusCode** | 1 | Integer | The HTTP status code returned by the provider. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
@@ -184,8 +184,8 @@ import TabItem from '@theme/TabItem';
                 OptionsQuota = 170,
                 BusinessRuleType = "CheaperAmount"
             },
-            Timeout = "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:00"),
+            Timeout = "00:00:10",
+            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:10"),
             IncludeProviderTransactions = true
         }
     };
@@ -337,8 +337,8 @@ import TabItem from '@theme/TabItem';
                 "optionsQuota": 170,
                 "businessRuleType": "CheaperAmount"
             },
-            "timeout": "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            "timeoutAsTimeSpan": "00:00:00",
+            "timeout": "00:00:10",
+            "timeoutAsTimeSpan": "00:00:10",
             "includeProviderTransactions": true
         }
     }
@@ -522,7 +522,7 @@ import TabItem from '@theme/TabItem';
 | **Settings/BusinessRules** | 0 . . 1 | [BusinessRules](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrules) | Specifies the business rules to be applied during the operation. These rules define operational constraints and behavior, such as quota limits or prioritization criteria. | 
 | **Settings/BusinessRules/**<br />**OptionsQuota** | 0 . . 1 | Integer | The maximum number of options returned for each board in the Search query. | 
 | **Settings/BusinessRules/**<br />**BusinessRuleType** | 1 | [BusinessRulesType](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrulestype) | The business rule type that determines how Search results are prioritized or filtered. | 
-| **Settings/Timeout** | 1 | String | Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:05:00" for 5 minutes). | 
+| **Settings/Timeout** | 1 | String | Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:00:10" for 10 seconds). | 
 | **Settings/TimeoutAsTimeSpan** | 0 . . 1 | String | Converts the timeout value from the string representation (Timeout) into a TimeSpan for use in time-based operations. | 
 | **Settings/**<br />**IncludeProviderTransactions** | 1 | Boolean | Indicates whether detailed traces of provider transactions should be included in the operation's response.If enabled, the ProviderAudit field in responses will contain the transaction logs (e.g., requests and responses exchanged with the supplier). | 
 | **Settings/CommitRequired** | 0 . . 1 | Boolean | Indicates whether a commit is required for the booking. | 

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
@@ -146,8 +146,8 @@ import TabItem from '@theme/TabItem';
                     RoomId = 105
                 }
             },
-            CheckIn = DateTime.Parse("2024-05-12"),
-            CheckOut = DateTime.Parse("2024-05-14"),
+            CheckIn = "2024-05-12",
+            CheckOut = "2024-05-14",
             TotalNights = 2,
             Language = "ES",
             Currency = "EUR",
@@ -354,8 +354,8 @@ import TabItem from '@theme/TabItem';
 | **BookCriteria** | 1 | [BookCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/bookcriteria) | The booking criteria for the hotel reservation. | 
 | **BookCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
 | **BookCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
-| **BookCriteria/CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object. | 
-| **BookCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object. | 
+| **BookCriteria/CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object, expressed in UTC 0 | 
+| **BookCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object, expressed in UTC 0 | 
 | **BookCriteria/TotalNights** | 0 . . 1 | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. | 
 | **BookCriteria/Language** | 1 | String | The language code for the operation, represented as a 2-character ISO 639-1 code (e.g., "en", "es"). | 
 | **BookCriteria/Currency** | 0 . . 1 | [Currency](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/currency) | The preferred currency for the operation, defined as an optional Currency value. | 

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
@@ -5,8 +5,8 @@ sidebar_position: 4
 
 ## **Overview**
 
-The `Book` operation is the final step in the booking workflow, used to confirm a reservation for a selected option. It involves providing detailed guest information, payment details (if required), and a client locator. Once completed, the supplier processes the reservation and returns its status.
-
+The `Book` operation is the final step in the booking workflow, used to confirm a reservation for a selected option. It involves providing detailed guest information, a client locator, the payment type, and credit card information when required. Once completed, the supplier processes the reservation and returns its status.
+                                             
 The `Book` operation ensures:
 - **Guest Information Submission**: Transfers passenger details, including names, surnames, and any additional guest-specific data, to the supplier.
 - **Payment Validation**: Confirms and processes payment if the supplier requires it at the booking stage.
@@ -20,7 +20,7 @@ When to Use:
 > **Note**: If the booking status is returned as `Unknown`, the Buyer is responsible for verifying with the Seller that the booking has been confirmed.
 
 Common Scenarios:
-- **Payment-Required Suppliers**: Includes credit card information or other payment details as part of the `Book` request.
+- **Payment-Required Suppliers**: Includes credit card information as part of the `Book` request.
 - **Error Handling**: Common errors include:
   - `SupplierBookingNotConfirmed`: Indicates that the booking could not be processed by the supplier.
   - `ItemNotAvailable`: Returned if the selected option is no longer valid at the time of booking.

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Book.mdx
@@ -352,8 +352,8 @@ import TabItem from '@theme/TabItem';
 | Name | Relation | Type | Description |
 |------|:--------:|:----:|-------------|
 | **BookCriteria** | 1 | [BookCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/bookcriteria) | The booking criteria for the hotel reservation. | 
-| **BookCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
-| **BookCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
+| **BookCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). | 
+| **BookCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). | 
 | **BookCriteria/CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object, expressed in UTC 0 | 
 | **BookCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object, expressed in UTC 0 | 
 | **BookCriteria/TotalNights** | 0 . . 1 | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. | 

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
@@ -224,8 +224,8 @@ import TabItem from '@theme/TabItem';
                 OptionsQuota = 170,
                 BusinessRuleType = "CheaperAmount"
             },
-            Timeout = "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:00"),
+            Timeout = "00:00:10",
+            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:10"),
             IncludeProviderTransactions = true
         }
     };
@@ -316,8 +316,8 @@ import TabItem from '@theme/TabItem';
             "optionsQuota": 170,
             "businessRuleType": "CheaperAmount"
         },
-        "timeout": "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-        "timeoutAsTimeSpan": "00:00:00",
+        "timeout": "00:00:10",
+        "timeoutAsTimeSpan": "00:00:10",
         "includeProviderTransactions": true
     }
 }
@@ -464,7 +464,7 @@ import TabItem from '@theme/TabItem';
 | **Settings/BusinessRules** | 0 . . 1 | [BusinessRules](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrules) | Specifies the business rules to be applied during the operation. These rules define operational constraints and behavior, such as quota limits or prioritization criteria. | 
 | **Settings/BusinessRules/**<br />**OptionsQuota** | 0 . . 1 | Integer | The maximum number of options returned for each board in the Search query. | 
 | **Settings/BusinessRules/**<br />**BusinessRuleType** | 0 . . 1 | [BusinessRulesType](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrulestype) | The business rule type that determines how Search results are prioritized or filtered. | 
-| **Settings/Timeout** | 1 | String | Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:05:00" for 5 minutes). | 
+| **Settings/Timeout** | 1 | String | Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:00:10" for 10 seconds). | 
 | **Settings/TimeoutAsTimeSpan** | 0 . . 1 | String | Converts the timeout value from the string representation (Timeout) into a TimeSpan for use in time-based operations. | 
 | **Settings/**<br />**IncludeProviderTransactions** | 1 | Boolean | Indicates whether detailed traces of provider transactions should be included in the operation's response.If enabled, the ProviderAudit field in responses will contain the transaction logs (e.g., requests and responses exchanged with the supplier). | 
 <!-- TABLE END -->

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
@@ -856,14 +856,14 @@ The `Quote` operation returns:
 |------|:--------:|:----:|-------------|
 | **AuditData** | 1 | [ProviderAudit](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/provideraudit) | Contains the audit data detailing the requests and responses exchanged with the supplier.This field is populated internally by the connector framework. | 
 | **AuditData/Request** | 0 . . N | Array&lt;[ProviderAuditRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrq)&gt; | Collection of audit entries for provider requests.Each entry contains details about a specific request made to the provider. | 
-| **AuditData/Request/SendAt** | 1 | String | The timestamp indicating when the request was sent. | 
+| **AuditData/Request/SendAt** | 1 | String | The timestamp indicating when the request was sent. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) | 
 | **AuditData/Request/Data** | 1 | String | The payload data included in the request. | 
 | **AuditData/Request/Url** | 1 | String | The URL of the provider endpoint to which the request is sent. | 
 | **AuditData/Request/Headers** | 1 | Object | A collection of headers included in the request. | 
 | **AuditData/Request/HttpMethod** | 1 | [HttpMethod](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/httpmethod) | The HTTP method used to send the request. | 
 | **AuditData/Request/HttpMethod/**<br />**Method** | 1 | String | No description available. | 
 | **AuditData/Response** | 0 . . N | Array&lt;[ProviderAuditRs](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrs)&gt; | Collection of audit entries for provider responses.Each entry contains details about a specific response received from the provider. | 
-| **AuditData/Response/ReceivedAt** | 1 | String | The timestamp indicating when the response was received. | 
+| **AuditData/Response/ReceivedAt** | 1 | String | The timestamp indicating when the response was received. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) | 
 | **AuditData/Response/Data** | 1 | String | The payload data contained in the provider's response. | 
 | **AuditData/Response/Headers** | 1 | Object | A collection of headers included in the provider's response. | 
 | **AuditData/Response/StatusCode** | 1 | Integer | The HTTP status code returned by the provider. | 

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
@@ -186,8 +186,8 @@ import TabItem from '@theme/TabItem';
                     RoomId = 1
                 }
             },
-            CheckIn = DateTime.Parse("2024-05-12"),
-            CheckOut = DateTime.Parse("2024-05-14"),
+            CheckIn = "2024-05-12",
+            CheckOut = "2024-05-14",
             TotalNights = 2,
             Language = "en",
             Currency = "EUR",
@@ -333,8 +333,8 @@ import TabItem from '@theme/TabItem';
 | **QuoteCriteria** | 1 | [QuoteCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/quotecriteria) | Criteria for the Quote request, such as dates, selected rooms, or other Search-related parameters. | 
 | **QuoteCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
 | **QuoteCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
-| **QuoteCriteria/**<br />**CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object. | 
-| **QuoteCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object. | 
+| **QuoteCriteria/**<br />**CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object, expressed in UTC 0 | 
+| **QuoteCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object, expressed in UTC 0 | 
 | **QuoteCriteria/TotalNights** | 0 . . 1 | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. | 
 | **QuoteCriteria/Language** | 1 | String | The language code for the operation, represented as a 2-character ISO 639-1 code (e.g., "en", "es"). | 
 | **QuoteCriteria/Currency** |  0 . . 1 | [Currency](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/currency) | The preferred currency for the operation, defined as an optional Currency value. | 

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Quote.mdx
@@ -331,8 +331,8 @@ import TabItem from '@theme/TabItem';
 | Name | Relation | Type | Description |
 |------|:--------:|:----:|-------------|
 | **QuoteCriteria** | 1 | [QuoteCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/quotecriteria) | Criteria for the Quote request, such as dates, selected rooms, or other Search-related parameters. | 
-| **QuoteCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
-| **QuoteCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). | 
+| **QuoteCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). | 
+| **QuoteCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). | 
 | **QuoteCriteria/**<br />**CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object, expressed in UTC 0 | 
 | **QuoteCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object, expressed in UTC 0 | 
 | **QuoteCriteria/TotalNights** | 0 . . 1 | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. | 

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
@@ -248,8 +248,8 @@ The object [SearchRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_
 | Name | Relation | Type | Description |
 |------|:--------:|:----:|-------------|
 | **SearchCriteria** | 1 | [SearchCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/searchcriteria) | Gets the Search criteria for the hotel Search. |
-| **SearchCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **SearchCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
+| **SearchCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
+| **SearchCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (YYYY-MM-DD). |
 | **SearchCriteria/**<br />**CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object, expressed in UTC 0 |
 | **SearchCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object, expressed in UTC 0 |
 | **SearchCriteria/TotalNights** | 0 . . 1 | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
@@ -958,14 +958,14 @@ The [SearchRs](/docs/apis/for-sellers/connectors-pull-developers-api/API_Referen
 |------|:--------:|:----:|-------------|
 | **AuditData** | 0 . . 1 | [ProviderAudit](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/provideraudit) | Contains the requests and responses exchanged with the supplier.This field is populated internally by the connector framework. Integrators do not need to handle this field manually. |
 | **AuditData/Request** | 0 . . N | Array&lt;[ProviderAuditRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrq)&gt; | Collection of audit entries for provider requests.Each entry contains details about a specific request made to the provider. |
-| **AuditData/Request/SendAt** | 1 | String | The timestamp indicating when the request was sent. |
+| **AuditData/Request/SendAt** | 1 | String | The timestamp indicating when the request was sent. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Request/Data** | 1 | String | The payload data included in the request. |
 | **AuditData/Request/Url** | 1 | String | The URL of the provider endpoint to which the request is sent. |
 | **AuditData/Request/Headers** | 1 | Object | A collection of headers included in the request. |
 | **AuditData/Request/HttpMethod** | 1 | [HttpMethod](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/httpmethod) | The HTTP method used to send the request. |
 | **AuditData/Request/HttpMethod/**<br />**Method** | 1 | String | No description available. |
 | **AuditData/Response** | 0 . . N | Array&lt;[ProviderAuditRs](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrs)&gt; | Collection of audit entries for provider responses.Each entry contains details about a specific response received from the provider. |
-| **AuditData/Response/ReceivedAt** | 1 | String | The timestamp indicating when the response was received. |
+| **AuditData/Response/ReceivedAt** | 1 | String | The timestamp indicating when the response was received. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Response/Data** | 1 | String | The payload data contained in the provider's response. |
 | **AuditData/Response/Headers** | 1 | Object | A collection of headers included in the provider's response. |
 | **AuditData/Response/StatusCode** | 1 | Integer | The HTTP status code returned by the provider. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
@@ -73,10 +73,10 @@ var request = new SearchRequest
                 }
             },
             Markets = new List<string> { "EU" },
-            CheckIn = DateTime.Parse("2025-06-10"),
-            CheckOut = DateTime.Parse("2025-06-15"),
-            CheckInAsDateTime = DateTime.Parse("2025-06-10T15:00:00"),
-            CheckOutAsDateTime = DateTime.Parse("2025-06-15T11:00:00"),
+            CheckIn = "2025-06-10",
+            CheckOut = "2025-06-15",
+            CheckInAsDateTime = DateTime.Parse("2025-06-10", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal),
+            CheckOutAsDateTime = DateTime.Parse("2025-06-15", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal),
             TotalNights = 5,
             Language = "EN",
             Currency = "EUR",
@@ -167,8 +167,8 @@ var request = new SearchRequest
         ],
         "checkIn": "2025-06-10",
         "checkOut": "2025-06-15",
-        "checkInAsDateTime": "2025-06-10T15:00:00",
-        "checkOutAsDateTime": "2025-06-15T11:00:00",
+        "checkInAsDateTime": "2025-06-10T00:00:00",
+        "checkOutAsDateTime": "2025-06-15T00:00:00",
         "totalNights": 5,
         "language": "EN",
         "currency": "EUR",
@@ -250,8 +250,8 @@ The object [SearchRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_
 | **SearchCriteria** | 1 | [SearchCriteria](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/searchcriteria) | Gets the Search criteria for the hotel Search. |
 | **SearchCriteria/CheckIn** | 1 | String | The check-in date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
 | **SearchCriteria/CheckOut** | 1 | String | The check-out date for the operation, represented as a string in ISO 8601 format (yyyy-MM-dd). |
-| **SearchCriteria/**<br />**CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object. |
-| **SearchCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object. |
+| **SearchCriteria/**<br />**CheckInAsDateTime** | 0 . . 1 | String | The check-in date parsed as a DateTime object, expressed in UTC 0 |
+| **SearchCriteria/**<br />**CheckOutAsDateTime** | 0 . . 1 | String | The check-out date parsed as a DateTime object, expressed in UTC 0 |
 | **SearchCriteria/TotalNights** | 0 . . 1 | Integer | The total number of nights for the stay, calculated as the difference between check-in and check-out dates. |
 | **SearchCriteria/Language** | 1 | String | The language code for the operation, represented as a 2-character ISO 639-1 code (e.g., "en", "es"). |
 | **SearchCriteria/Currency** | 0 . . 1 | [Currency](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/currency) | The preferred currency for the operation, defined as an optional Currency value. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Flow/Search.mdx
@@ -113,8 +113,8 @@ var request = new SearchRequest
                 OptionsQuota = 10,
                 BusinessRuleType = "CheaperAmount"
             },
-            Timeout = "30s",
-            TimeoutAsTimeSpan = TimeSpan.FromSeconds(30),
+            Timeout = "00:00:10",
+            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:10"),
             IncludeProviderTransactions = true
         },
         Filters = new Filters
@@ -205,8 +205,8 @@ var request = new SearchRequest
             "optionsQuota": 10,
             "businessRuleType": "CheaperAmount"
         },
-        "timeout": "30s",
-        "timeoutAsTimeSpan": "00:00:30",
+        "timeout": "00:00:10",
+        "timeoutAsTimeSpan": "00:00:10",
         "includeProviderTransactions": true
     },
     "filters":
@@ -288,7 +288,7 @@ The object [SearchRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_
 | **Settings/BusinessRules** | 0 . . 1 | [BusinessRules](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrules) | Specifies the business rules to be applied during the operation. These rules define operational constraints and behavior, such as quota limits or prioritization criteria. |
 | **Settings/BusinessRules/**<br />**OptionsQuota** | 0 . . 1 | Integer | The maximum number of options returned for each board in the Search query. |
 | **Settings/BusinessRules/**<br />**BusinessRuleType** | 0 . . 1 | [BusinessRulesType](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrulestype) | The business rule type that determines how Search results are prioritized or filtered. |
-| **Settings/Timeout** | 1 | String | Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:05:00" for 5 minutes). |
+| **Settings/Timeout** | 1 | String | Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in TimeSpan format (e.g., ""00:00:10"" for 10 seconds). |
 | **Settings/TimeoutAsTimeSpan** | 0 . . 1 | String | Converts the timeout value from the string representation (Timeout) into a TimeSpan for use in time-based operations. |
 | **Settings/**<br />**IncludeProviderTransactions** | 1 | Boolean | Indicates whether detailed traces of provider transactions should be included in the operation's response.If enabled, the ProviderAudit field in responses will contain the transaction logs (e.g., requests and responses exchanged with the supplier). |
 | **Filters** | 1 | [Filters](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/filters) | Gets the filters to be applied to the hotel Search results. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/Cancel.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/Cancel.mdx
@@ -387,14 +387,14 @@ The `Cancel` operation provides:
 |------|:--------:|:----:|-------------|
 | **AuditData** | 1 | [ProviderAudit](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/provideraudit) | Gets or sets the audit data provided by the supplier or system for the operation. |
 | **AuditData/Request** | 0 . . N | Array&lt;[ProviderAuditRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrq)&gt; |  Collection of audit entries for provider requests.Each entry contains details about a specific request made to the provider. |
-| **AuditData/Request/SendAt** | 1 | String |  The timestamp indicating when the request was sent. |
+| **AuditData/Request/SendAt** | 1 | String |  The timestamp indicating when the request was sent. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Request/Data** | 1 | String |  The payload data included in the request. |
 | **AuditData/Request/Url** | 1 | String |  The URL of the provider endpoint to which the request is sent. |
 | **AuditData/Request/Headers** | 1 | Object |  A collection of headers included in the request. |
 | **AuditData/Request/HttpMethod** | 1 | [HttpMethod](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/httpmethod) |  The HTTP method used to send the request. |
 | **AuditData/Request/HttpMethod/**<br />**Method** | 1 | String |  No description available. |
 | **AuditData/Response** | 0 . . N | Array&lt;[ProviderAuditRs](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrs)&gt; |  Collection of audit entries for provider responses.Each entry contains details about a specific response received from the provider. |
-| **AuditData/Response/ReceivedAt** | 1 | String |  The timestamp indicating when the response was received. |
+| **AuditData/Response/ReceivedAt** | 1 | String |  The timestamp indicating when the response was received. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Response/Data** | 1 | String |  The payload data contained in the provider's response. |
 | **AuditData/Response/Headers** | 1 | Object |  A collection of headers included in the provider's response. |
 | **AuditData/Response/StatusCode** | 1 | Integer |  The HTTP status code returned by the provider. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/Cancel.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/Cancel.mdx
@@ -85,8 +85,8 @@ import TabItem from '@theme/TabItem';
                 OptionsQuota = 170,
                 BusinessRuleType = "CheaperAmount"
             },
-            Timeout = "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:00"),
+            Timeout = "00:00:10",
+            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:10"),
             IncludeProviderTransactions = true
         }
     };
@@ -143,8 +143,8 @@ import TabItem from '@theme/TabItem';
                 "optionsQuota": 170,
                 "businessRuleType": "CheaperAmount"
             },
-            "timeout": "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            "timeoutAsTimeSpan": "00:00:00",
+            "timeout": "00:00:10",
+            "timeoutAsTimeSpan": "00:00:10",
             "includeProviderTransactions": true
         }
     }
@@ -185,7 +185,7 @@ import TabItem from '@theme/TabItem';
 | **Settings/BusinessRules** |0 . . 1 | [BusinessRules](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrules) |  Specifies the business rules to be applied during the operation. These rules define operational constraints and behavior, such as quota limits or prioritization criteria. |
 | **Settings/BusinessRules/**<br />**OptionsQuota** | 0 . . 1 | Integer |  The maximum number of options returned for each board in the Search query. |
 | **Settings/BusinessRules/**<br />**BusinessRuleType** | 1 | [BusinessRulesType](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrulestype) |  The business rule type that determines how Search results are prioritized or filtered. |
-| **Settings/Timeout** | 1 | String |  Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:05:00" for 5 minutes). |
+| **Settings/Timeout** | 1 | String |  Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:00:10" for 10 seconds). |
 | **Settings/TimeoutAsTimeSpan** | 0 . . 1 | String |  Converts the timeout value from the string representation (Timeout) into a TimeSpan for use in time-based operations. |
 | **Settings/**<br />**IncludeProviderTransactions** | 1 | Boolean |  Indicates whether detailed traces of provider transactions should be included in the operation's response.If enabled, the ProviderAudit field in responses will contain the transaction logs (e.g., requests and responses exchanged with the supplier). |
 <!-- TABLE END -->

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Dates.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Dates.mdx
@@ -87,8 +87,8 @@ import TabItem from '@theme/TabItem';
                 OptionsQuota = 170,
                 BusinessRuleType = "CheaperAmount"
             },
-            Timeout = "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:00"),
+            Timeout = "00:00:10",
+            TimeoutAsTimeSpan = TimeSpan.Parse("00:00:10"),
             IncludeProviderTransactions = true
         }
     };
@@ -138,8 +138,8 @@ import TabItem from '@theme/TabItem';
                 "optionsQuota": 170,
                 "businessRuleType": "CheaperAmount"
             },
-            "timeout": "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            "timeoutAsTimeSpan": "00:00:00",
+            "timeout": "00:00:10",
+            "timeoutAsTimeSpan": "00:00:10",
             "includeProviderTransactions": true
         }
     }
@@ -170,7 +170,7 @@ import TabItem from '@theme/TabItem';
 | **Settings/BusinessRules** | 0 . . 1 | [BusinessRules](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrules) |  Specifies the business rules to be applied during the operation. These rules define operational constraints and behavior, such as quota limits or prioritization criteria. |
 | **Settings/BusinessRules/**<br />**OptionsQuota** | 0 . . 1 | Integer |  The maximum number of options returned for each board in the Search query. |
 | **Settings/BusinessRules/**<br />**BusinessRuleType** | 0 . . 1 | [BusinessRulesType](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrulestype) |  The business rule type that determines how Search results are prioritized or filtered. |
-| **Settings/Timeout** | 1 | String |  Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:05:00" for 5 minutes). |
+| **Settings/Timeout** | 1 | String |  Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:00:10" for 10 seconds). |
 | **Settings/TimeoutAsTimeSpan** | 0 . . 1 | String |  Converts the timeout value from the string representation (Timeout) into a TimeSpan for use in time-based operations. |
 | **Settings/**<br />**IncludeProviderTransactions** | 1 | Boolean |  Indicates whether detailed traces of provider transactions should be included in the operation's response.If enabled, the ProviderAudit field in responses will contain the transaction logs (e.g., requests and responses exchanged with the supplier). |
 | **Input** | 1 | [CheckBookingsByDateInput](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/checkbookingsbydateinput) |  Contains the details for checking bookings within a specific date range. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Dates.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Dates.mdx
@@ -626,14 +626,14 @@ The Response Object provides a list of bookings within the specified date range,
 |------|:--------:|:----:|-------------|
 | **AuditData** | 1 | [ProviderAudit](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/provideraudit) |  Provides detailed audit data for the supplier transactions, including request and response logs. |
 | **AuditData/Request** | 0 . . N | Array&lt;[ProviderAuditRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrq)&gt; |  Collection of audit entries for provider requests.Each entry contains details about a specific request made to the provider. |
-| **AuditData/Request/SendAt** | 1 | String |  The timestamp indicating when the request was sent. |
+| **AuditData/Request/SendAt** | 1 | String |  The timestamp indicating when the request was sent. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Request/Data** | 1 | String |  The payload data included in the request. |
 | **AuditData/Request/Url** | 1 | String |  The URL of the provider endpoint to which the request is sent. |
 | **AuditData/Request/Headers** | 1 | Object |  A collection of headers included in the request. |
 | **AuditData/Request/HttpMethod** | 1 | [HttpMethod](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/httpmethod) |  The HTTP method used to send the request. |
 | **AuditData/Request/HttpMethod/**<br />**Method** | 1 | String |  No description available. |
 | **AuditData/Response** | 0 . . N | Array&lt;[ProviderAuditRs](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrs)&gt; |  Collection of audit entries for provider responses.Each entry contains details about a specific response received from the provider. |
-| **AuditData/Response/ReceivedAt** | 1 | String |  The timestamp indicating when the response was received. |
+| **AuditData/Response/ReceivedAt** | 1 | String |  The timestamp indicating when the response was received. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Response/Data** | 1 | String |  The payload data contained in the provider's response. |
 | **AuditData/Response/Headers** | 1 | Object |  A collection of headers included in the provider's response. |
 | **AuditData/Response/StatusCode** | 1 | Integer |  The HTTP status code returned by the provider. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Dates.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Dates.mdx
@@ -50,8 +50,8 @@ import TabItem from '@theme/TabItem';
     {
         Input = new CheckBookingsByDateInput
         {
-            CheckIn = DateTime.Parse("2024-05-12"),
-            CheckOut = DateTime.Parse("2024-05-14"),
+            CheckIn = "2024-05-12",
+            CheckOut = "2024-05-14",
             DateType = "Arrival",
             Language = "ES",
             Currency = "EUR"
@@ -176,8 +176,8 @@ import TabItem from '@theme/TabItem';
 | **Input** | 1 | [CheckBookingsByDateInput](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/checkbookingsbydateinput) |  Contains the details for checking bookings within a specific date range. |
 | **Input/CheckIn** | 1 | String |  The check-in date for the booking check, specified as a string. |
 | **Input/CheckOut** | 1 | String |  The check-out date for the booking check, specified as a string. |
-| **Input/CheckInAsDateTime** | 0 . . 1 | String |  Parses and returns the check-in date as a DateTime object. |
-| **Input/CheckOutAsDateTime** | 0 . . 1 | String |  Parses and returns the check-out date as a DateTime object. |
+| **Input/CheckInAsDateTime** | 0 . . 1 | String |  The check-in date parsed as a DateTime object, expressed in UTC 0 |
+| **Input/CheckOutAsDateTime** | 0 . . 1 | String |  The check-out date parsed as a DateTime object, expressed in UTC 0 |
 | **Input/DateType** | 1 | [DateRangeType](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/daterangetype) |  Specifies the type of date range to use for the booking check. |
 | **Input/Language** | 0 . . 1 | String |  The language code to be used for the booking check. |
 | **Input/Currency** | 0 . . 1 | [Currency](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/currency) |  The currency to be used for the booking check. |
@@ -663,8 +663,8 @@ The Response Object provides a list of bookings within the specified date range,
 | **Bookings/Hotel/BookingDate** | 0 . . 1 | String |  The date when the booking was created. |
 | **Bookings/Hotel/CheckIn** | 0 . . 1 | String |  The check-in date for the booking. |
 | **Bookings/Hotel/CheckOut** | 0 . . 1 | String |  The check-out date for the booking. |
-| **Bookings/Hotel/**<br />**CheckInAsDateTime** | 0 . . 1 | String |  The check-in date as a DateTime object. |
-| **Bookings/Hotel/**<br />**CheckOutAsDateTime** | 0 . . 1 | String |  The check-out date as a DateTime object. |
+| **Bookings/Hotel/**<br />**CheckInAsDateTime** | 0 . . 1 | String |  The check-in date parsed as a DateTime object, expressed in UTC 0 |
+| **Bookings/Hotel/**<br />**CheckOutAsDateTime** | 0 . . 1 | String |  The check-out date parsed as a DateTime object, expressed in UTC 0 |
 | **Bookings/Hotel/HotelCode** | 0 . . 1 | String |  The unique code identifying the hotel. |
 | **Bookings/Hotel/HotelName** | 0 . . 1 | String |  The name of the hotel associated with the booking. |
 | **Bookings/Hotel/BoardCode** | 0 . . 1 | String |  The board code for the booking. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Reference.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Reference.mdx
@@ -91,8 +91,8 @@ import TabItem from '@theme/TabItem';
                 OptionsQuota = 170,
                 BusinessRuleType = "CheaperAmount"
             },
-            Timeout = "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            TimeoutAsTimeSpan = "00:00:00",
+            Timeout = "00:00:10",
+            TimeoutAsTimeSpan = "00:00:10",
             IncludeProviderTransactions = true
         }
     };
@@ -150,8 +150,8 @@ import TabItem from '@theme/TabItem';
                 "optionsQuota": 170,
                 "businessRuleType": "CheaperAmount"
             },
-            "timeout": "Timeout7d64fd74-9c49-46d7-aa62-2a14c9500e2f",
-            "timeoutAsTimeSpan": "00:00:00",
+            "timeout": "00:00:10",
+            "timeoutAsTimeSpan": "00:00:10",
             "includeProviderTransactions": true
         }
     }
@@ -182,7 +182,7 @@ import TabItem from '@theme/TabItem';
 | **Settings/BusinessRules** | 0 . . 1 | [BusinessRules](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrules) |  Specifies the business rules to be applied during the operation. These rules define operational constraints and behavior, such as quota limits or prioritization criteria. |
 | **Settings/BusinessRules/**<br />**OptionsQuota** | 0 . . 1 | Integer |  The maximum number of options returned for each board in the Search query. |
 | **Settings/BusinessRules/**<br />**BusinessRuleType** | 0 . . 1 | [BusinessRulesType](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/businessrulestype) |  The business rule type that determines how Search results are prioritized or filtered. |
-| **Settings/Timeout** | 1 | String |  Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:05:00" for 5 minutes). |
+| **Settings/Timeout** | 1 | String |  Defines the timeout period for the operation as a string value.This indicates the maximum amount of time to wait for a supplier's response before timing out.The value must be provided in timestamp format (e.g., "00:00:10" for 10 seconds). |
 | **Settings/TimeoutAsTimeSpan** | 0 . . 1 | String |  Converts the timeout value from the string representation (Timeout) into a TimeSpan for use in time-based operations. |
 | **Settings/**<br />**IncludeProviderTransactions** | 1 | Boolean |  Indicates whether detailed traces of provider transactions should be included in the operation's response.If enabled, the ProviderAudit field in responses will contain the transaction logs (e.g., requests and responses exchanged with the supplier). |
 | **Input** | 1 | [CheckBookingsByReferenceInput](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/checkbookingsbyreferenceinput) |  Specifies the input details required for the booking reference check. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Reference.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Reference.mdx
@@ -639,14 +639,14 @@ The Response Object provides the booking status, optional details, and any warni
 |------|:--------:|:----:|-------------|
 | **AuditData** | 1 | [ProviderAudit](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/provideraudit) |  Provides detailed audit data for the supplier transactions, including request and response logs. |
 | **AuditData/Request** | 0 . . N | Array&lt;[ProviderAuditRq](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrq)&gt; |  Collection of audit entries for provider requests.Each entry contains details about a specific request made to the provider. |
-| **AuditData/Request/SendAt** | 1 | String |  The timestamp indicating when the request was sent. |
+| **AuditData/Request/SendAt** | 1 | String |  The timestamp indicating when the request was sent. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Request/Data** | 1 | String |  The payload data included in the request. |
 | **AuditData/Request/Url** | 1 | String |  The URL of the provider endpoint to which the request is sent. |
 | **AuditData/Request/Headers** | 1 | Object |  A collection of headers included in the request. |
 | **AuditData/Request/HttpMethod** | 1 | [HttpMethod](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/httpmethod) |  The HTTP method used to send the request. |
 | **AuditData/Request/HttpMethod/**<br />**Method** | 1 | String |  No description available. |
 | **AuditData/Response** | 0 . . N | Array&lt;[ProviderAuditRs](/docs/apis/for-sellers/connectors-pull-developers-api/API_Reference/providerauditrs)&gt; |  Collection of audit entries for provider responses.Each entry contains details about a specific response received from the provider. |
-| **AuditData/Response/ReceivedAt** | 1 | String |  The timestamp indicating when the response was received. |
+| **AuditData/Response/ReceivedAt** | 1 | String |  The timestamp indicating when the response was received. Date on UTC Standard (ISO 8601 UTC `2025-05-21T08:48:53.9744052+00:00`) |
 | **AuditData/Response/Data** | 1 | String |  The payload data contained in the provider's response. |
 | **AuditData/Response/Headers** | 1 | Object |  A collection of headers included in the provider's response. |
 | **AuditData/Response/StatusCode** | 1 | Integer |  The HTTP status code returned by the provider. |

--- a/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Reference.mdx
+++ b/docs/apis/for-sellers/connectors-pull-developers-api/Booking_Management_Flow/CheckBookings_By_Reference.mdx
@@ -676,8 +676,8 @@ The Response Object provides the booking status, optional details, and any warni
 | **Bookings/Hotel/BookingDate** | 0 . . 1 | String |  The date when the booking was created. |
 | **Bookings/Hotel/CheckIn** | 0 . . 1 | String |  The check-in date for the booking. |
 | **Bookings/Hotel/CheckOut** | 0 . . 1 | String |  The check-out date for the booking. |
-| **Bookings/Hotel/**<br />**CheckInAsDateTime** | 0 . . 1 | String |  The check-in date as a DateTime object. |
-| **Bookings/Hotel/**<br />**CheckOutAsDateTime** | 0 . . 1 | String |  The check-out date as a DateTime object. |
+| **Bookings/Hotel/**<br />**CheckInAsDateTime** | 0 . . 1 | String |  The check-in date parsed as a DateTime object, expressed in UTC 0 |
+| **Bookings/Hotel/**<br />**CheckOutAsDateTime** | 0 . . 1 | String |  The check-out date parsed as a DateTime object, expressed in UTC 0 |
 | **Bookings/Hotel/HotelCode** | 0 . . 1 | String |  The unique code identifying the hotel. |
 | **Bookings/Hotel/HotelName** | 0 . . 1 | String |  The name of the hotel associated with the booking. |
 | **Bookings/Hotel/BoardCode** | 0 . . 1 | String |  The board code for the booking. |


### PR DESCRIPTION
- The examples for the CheckIn and CheckOut fields have been corrected. It has also been specified in the  
   description of CheckInAsDateTime and CheckOutAsDateTime that they are in UTC 0.

- All descriptions referring to this date format (yyyy-MM-dd) have been capitalised.

- The examples for Timeout have been corrected and set to 10 seconds throughout the connector 
   documentation for consistency.

- The information in one paragraph of the Book section has been modified as it could be confusing.

- It has been specified in the description of the ReceivedAt and SendAt fields that the date is in ISO 8601 
   UTC.

Jira Ticket: https://travelgatex.atlassian.net/browse/PULL-11972

