### PR TITLE
feat: Update currencies documentation

### DIFF
--- a/src/graphql/generated-docs/MetadataConnection.mdx
+++ b/src/graphql/generated-docs/MetadataConnection.mdx
@@ -2470,9 +2470,9 @@
           
           <details style={{ pointerEvents: "none" }}>
             <summary>
-              <strong>codes</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String[])</em>
+              <strong>codes</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
             </summary>
-
+            List of ISO 4217 currency codes accepted in the booking flow.
           </details>
         </details>
 

--- a/src/graphql/generated-docs/MetadataConnection.mdx
+++ b/src/graphql/generated-docs/MetadataConnection.mdx
@@ -2421,10 +2421,10 @@
 
         <details>
           <summary>
-            <strong>currencies</strong> <em>(MetadataContent)</em>
+            <strong>currencies</strong> <em>(MetadataContentCurrency)</em>
           </summary>
           Contains information regarding Currencies, Currencies returns a list of currencies the supplier in booking flow.
-          Return null is not implemented
+          The currency format complies with ISO 4217. Return null is not implemented
 
           <details>
             <summary>
@@ -2466,6 +2466,13 @@
               </summary>
 
             </details>
+          </details>
+          
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>codes</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String[])</em>
+            </summary>
+
           </details>
         </details>
 

--- a/src/graphql/generated-docs/MetadataConnection.mdx
+++ b/src/graphql/generated-docs/MetadataConnection.mdx
@@ -2472,7 +2472,6 @@
             <summary>
               <strong>codes</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
             </summary>
-            List of ISO 4217 currency codes accepted in the booking flow.
           </details>
         </details>
 


### PR DESCRIPTION
A new field called ‘codes’ has been added, which contains a list of currency codes that the supplier accepts in the booking flow.

<img width="2528" height="911" alt="image" src="https://github.com/user-attachments/assets/29339bba-341b-42c2-ad88-c0877e452984" />


Ticket: https://travelgatex.atlassian.net/browse/PULL-12326
