### PR TITLE
fix(csv-api): correct documentation discrepancies vs service code

### DIFF
--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/masters/rooms-master.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/masters/rooms-master.mdx
@@ -17,7 +17,12 @@ To view existing master room data, clients can retrieve current details using th
 
 ### Filename Format
 
-The file naming format for the Rooms Master is as follows: **clientCode-roomsMaster.csv**.
+The file naming format for the Rooms Master supports two formats:
+
+- **clientCode-roomsMaster.csv** (without provider code)
+- **clientCode-providerCode-roomsMaster.csv** (with provider code)
+
+Both formats are valid and will be processed correctly by the system.
 
 If you have any questions about how to add the requested information to create the file name, you can check the following link:  
 [File Naming Importance for Travelgate FTP Uploads](../quickstart#3-file-naming-importance-for-travelgate-ftp-uploads)
@@ -44,6 +49,3 @@ Code;Name
 
 #### Data Uniqueness
 Master Room Codes: Each Code must be unique; duplication of master room codes within the same file or across multiple files for the same client is not permitted. Ensuring uniqueness is crucial for maintaining data integrity and avoiding conflicts in room identification within the platform.
-
-
-

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/quickstart.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/quickstart.mdx
@@ -133,6 +133,15 @@ Imagine you are the client "travelClient (TG)" connected to the channel manager 
 * **Example for Scenario 2:**
 Imagine you are the client "travelClient (TG)" connected to the channel manager "travelgateChannelManager (TGCM)", which uses hotel codes from the inventory. If you are completing the "rooms" file, the download file name should be: "clientCode(Inventory)-providerCode(Inventory)-HotelCode#ContextCode-rooms.csv. In this case, you would name the file "TG-TRVCM-1234-rooms.csv", omitting the #ContextCode since the connected channel does not use native codes but relies on Travelgate's inventory codes.
 
+:::caution
+**IMPORTANT**: The file name is parsed by the system using the dash (`-`) character as a separator. Make sure your client code and provider code do NOT contain dashes. The system expects the following patterns:
+- `clientCode-providerCode-entity.csv` (for masters like hotelsMaster)
+- `clientCode-providerCode-HotelCode#ContextCode-entity.csv` (for setups)
+- `clientCode-roomsMaster.csv` (special case for rooms master)
+
+The **entity** part must match one of the supported types exactly (case-insensitive): `hotels`, `rooms`, `rateplans`, `policies`, `taxes`, `offers`, `hotelsMaster`, `roomsMaster`.
+:::
+
 ### 4. Uploading Files to SFTP and Configuration 
 
 After completing the necessary preliminary steps, the next stage involves uploading your files to the SFTP server. 
@@ -148,7 +157,36 @@ When accessing the SFTP, you will find three folders in the main directory, each
 :::caution
 **IMPORTANT**: It is essential to use the correct file naming conventions to ensure the files can be processed via the SFTP.
 :::
+
 #### File Checking Frequency
-It is important to note that our CSV API checks the SFTP server every 10 seconds for new files. This frequent scanning ensures that any files you upload are quickly detected and processed, minimizing delay in data handling.
+It is important to note that our CSV API checks the SFTP server periodically for new files (approximately every hour). Once detected, files are queued for processing. The processing time depends on the file size and the current system load.
+
+:::info
+**File Processing Status:** After a file is picked up for processing, it will be renamed with a suffix indicating its status:
+- **-Processing**: The file is currently being processed.
+- **-Processed**: The file has been successfully processed.
+- **-Error**: An error occurred during processing. Check your file format and data.
+
+You can monitor these status changes on the SFTP to track the progress of your uploads.
+:::
 
 This guide will ensure you can securely transfer your files to the appropriate destination without any issues.
+
+### 5. CSV Format Requirements
+
+:::caution
+**Critical formatting rules that must be followed:**
+:::
+
+| Requirement | Details |
+|---|---|
+| **Delimiter** | Semicolon (`;`) — NOT comma, NOT tab |
+| **Encoding** | UTF-8 (recommended) or ANSI |
+| **Header row** | Must be present as the first line (it is skipped during processing) |
+| **Empty optional fields** | Leave the value empty between semicolons (e.g., `value1;;value3`) |
+| **Multi-value fields** | Use pipe (`\|`) as separator (e.g., `email1@test.com\|email2@test.com`) |
+| **Decimal numbers** | Both dot (`.`) and comma (`,`) are accepted as decimal separators |
+| **Date format** | `dd/MM/yyyy` (e.g., `14/04/2026`) |
+| **Boolean fields** | `1` = True, `0` = False |
+| **Line endings** | Both Windows (CRLF) and Unix (LF) are accepted |
+| **Quoting** | Optional — values may be enclosed in double quotes (`"value"`) |

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/policies.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/policies.mdx
@@ -19,21 +19,37 @@ If you have any questions about how to add the requested information to create t
 |-------------|-----|---------------------------------------------------------------------------------------------------|
 | Rate Code        |	  1   | Unique identifier that associate this policies to a unique rate. |
 | Refundable        |   1   | Indicate if it is a refundable policy or not. Example: (**0 - False** (not refundable)) or (**1 - True** (refundable)). |
-| Days Before        |   0   | Number of days prior to check-in when the cancellation policy takes effect. |
-| Penalty Value        |   0   | Amount to be paid if the book is canceled in the range of days that this policy is effective.([Check the Penalty Type Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/policies#additional-information)). |
-| Penalty Type        |   0   | Type of penalty to be chosen between: Percentage, Amount and Nights. |
+| Days Before        |   0   | Number of days prior to check-in when the cancellation policy takes effect. Leave empty for non-refundable policies. |
+| Penalty Value        |   0   | Amount to be paid if the book is canceled in the range of days that this policy is effective. Leave empty for non-refundable policies. ([Check the Penalty Type Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/policies#additional-information)). |
+| Penalty Type        |   0   | Type of penalty to be chosen between: Percentage, Amount and Nights. Leave empty for non-refundable policies. |
 | Start Date        |   0   | Indicate the starting date of the policy. Format date: dd/MM/yyyy. |
 | End Date        |   0   | Indicate the ending date of the policy. Format date: dd/MM/yyyy. |
+
+:::info
+**Non-Refundable Policies (NRF):** When `Refundable` is set to `0`, the fields `Days Before`, `Penalty Value`, and `Penalty Type` can be left empty. The system will interpret this as a fully non-refundable rate with no specific penalty details.
+:::
 
 #### Sheet Format Example
 
 ![inventory_csv_policies-setup](https://storage.travelgate.com/docs/inventory_csv_policies-setup.png)
 
 #### CSV Format Example for Channel Managers
+
+**Refundable policy:**
 ```
-Rate Code;Refundable;Days Before Arrival;Penalty Value;Penalty Type;Start Date;End Date
-"123RATE_TEST";"1";"2";"100";"Amount";"20/05/2024";"25/05/2024"
+Rate Code;Refundable;Days Before;Penalty Value;Penalty Type;Start Date;End Date
+"BAR_14";"1";"7";"100";"Amount";"14/04/2026";"31/12/2029"
 ```
+
+**Non-refundable policy (NRF):**
+```
+Rate Code;Refundable;Days Before;Penalty Value;Penalty Type;Start Date;End Date
+"NRF_14";"0";;;;"14/04/2026";"31/12/2029"
+```
+
+:::note
+Note that for NRF policies, the semicolons (`;`) must still be present as column separators even when the values are empty.
+:::
 
 ### Additional information
 

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/rateplans.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/rateplans.mdx
@@ -25,14 +25,18 @@ If you have any questions about how to add the requested information to create t
 | Max Age Infant        |   1   | Age limit for infant, inclusive. |
 | Booking From        |   0   | Starting Date which the rate will be available. Format date: dd/MM/yyyy. |
 | Booking To        |   0   | Ending Date which the rate will be available. Format date: dd/MM/yyyy. |
-| PaymentType        |   0   | List of accepted payment types for this rate ([Check the Payment Types Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/rateplans#paymenttype)). |
-| Commission        |   0   | Value of the rate's commission in the range 0-100. |
+| PaymentType        |   0   | List of accepted payment types for this rate, separated by pipe (\|) if multiple. ([Check the Payment Types Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/rateplans#paymenttype)). |
+| Commission        |   0   | Value of the rate's commission in the range 0-100. Can optionally include a `%` suffix (e.g., `18.5` or `18.5%` are both valid). Decimal separator must be a dot (`.`) or comma (`,`). |
 | Currency        |   1   | ISO code that identifies the currency of the rate, format code: ISO 4217 |
-| Markets Included        |   0   | List of included markets (ISO 3166-1 alpha-2) separated by pipe for this rate. |
-| Markets Excluded        |   0   | List of excluded markets (ISO 3166-1 alpha-2) separated by pipe for this rate. |
+| Markets Included        |   0   | List of included markets (ISO 3166-1 alpha-2) separated by pipe (\|) for this rate. |
+| Markets Excluded        |   0   | List of excluded markets (ISO 3166-1 alpha-2) separated by pipe (\|) for this rate. |
 | Meal Plan        |   0   | Meal plan included in rate ([Check the Meal Plan Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/rateplans#meal-plan)). |
 | Binding        |   0   | Indicate if the rate's price could be sold under the price shown. Example: (**0 - False** (binding price false)) or (**1 - True** (binding price true)). |
 | Senior Rule        |   0   | Sets the rate for senior citizens ([Check the Senior Rule Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/rateplans#senior-rule)). |
+
+:::caution
+**IMPORTANT**: The file must contain exactly **16 columns** (including empty optional ones). Rows with fewer columns will be skipped.
+:::
 
 #### Sheet Format Example
 
@@ -42,7 +46,7 @@ If you have any questions about how to add the requested information to create t
 
 ```
 Code;Name;Rate Rule;Active;Max Age Child;Max Age Infant;Booking From;Booking To;PaymentType;Commission;Currency;Markets Included;Markets Excluded;Meal Plan;Binding;Senior Rule
-123RATE_TEST;NameRate_test;;1;18;1;;;MerchantPay;;EUR;;;All inclusive;;
+123RATE_TEST;NameRate_test;;1;18;1;;;MerchantPay;18.5%;EUR;;;All inclusive;;
 ```
 
 ### Additional information

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/specific-clients.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/specific-clients.mdx
@@ -4,18 +4,21 @@ sidebar_position: 6
 
 # Specific Clients
 
-The Specific Clients file is designed to facilitate the setup of specific clients within the Inventory platform. It's necessary for managing specific client data and relate to the rates created previously.
+:::danger
+**NOT CURRENTLY SUPPORTED**: The Specific Clients CSV file is currently **not supported** by the processing system. Files named with the `-specificclients` suffix will be rejected as an unknown entity type.
 
-If you want to inform that this rate is only for a list of specific clients this is your csv: code (represent your client) and Description (name of the client). You can add maximum 15 clients. The client codes have to be unique on the same rate.
+If you need to configure specific clients for a rate, please use the [Inventory Set Up GraphQL API](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/) instead.
+:::
 
-### File Name Format
+~~The Specific Clients file is designed to facilitate the setup of specific clients within the Inventory platform. It's necessary for managing specific client data and relate to the rates created previously.~~
 
-The file name format for the Specific Client Setup is as follows: **clientCode-providerCode-HotelCode#ContextCode-specificclients.csv**.
+~~If you want to inform that this rate is only for a list of specific clients this is your csv: code (represent your client) and Description (name of the client). You can add maximum 15 clients. The client codes have to be unique on the same rate.~~
 
-If you have any questions about how to add the requested information to create the file name, you can consult the following link:  
-[Importance of the file name for Travelgate's FTP uploads](../quickstart#3-file-naming-importance-for-travelgate-ftp-uploads)
+### File Name Format (Not Supported)
 
-### Specific Client
+~~The file name format for the Specific Client Setup is as follows: **clientCode-providerCode-HotelCode#ContextCode-specificclients.csv**.~~
+
+### Specific Client (Not Supported)
 
 | Element     | Mandatory | Description                                                                                       |
 |-------------|-----|---------------------------------------------------------------------------------------------------|
@@ -23,13 +26,8 @@ If you have any questions about how to add the requested information to create t
 | Code        |   1   | Identifier of this specific client. |
 | Descriptions        |   1   | Detailed name of the specific client. |
 
-#### Sheet Format Example
-
-![inventory_csv_specificClients-setup](https://storage.travelgate.com/docs/inventory_csv_specificClients-setup.png)
-
-#### CSV Format Example for Channel Managers
+#### CSV Format Example
 ```
 Rate Code;Code;Descriptions
 "123RATE_TEST";"123_Ctest";"Client test"
 ```
-

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/taxes.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/taxes.mdx
@@ -19,11 +19,15 @@ If you have any questions about how to add the requested information to create t
 |-------------|-----|---------------------------------------------------------------------------------------------------|
 | Rate Code        |	  1   | Unique identifier that associate this surcharge to a unique rate code. |
 | Charge Type        |   1   | Indicate if the surcharge is included or not in the final price. Example: (**0** - Included (included in the final price)) or (**1** - Excluded (excluded the final price)). |
-| ApplyType        |   1   | Number of days prior to check-in when the cancellation policy takes effect. Type of payment to be chosen between: ([Check the ApplyType Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/taxes#applytype)) |
-| Value        |   1   | Amount to be paid. |
-| Type        |   1   | Indicate the surcharge type ([Check the Penalty Type Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/taxes#type)). |
+| Type        |   1   | Indicate the surcharge type ([Check the Type Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/taxes#type)). |
+| ApplyType        |   1   | Indicate the apply type of the tax value ([Check the ApplyType Codes](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/set-up/taxes#applytype)). |
+| Value        |   1   | Amount or percentage to be paid. |
 | Is Per Night        |   0   | Indicate if it is a surcharge that applies per day or not. Example: (**0** - False (not apply per day)) or (**1** - True (apply per day)). |
 | Is Per Pax        |   0   | Indicate if it is a surcharge that applies per pax or not. Example: (**0** - False (not apply per pax)) or (**1** - True (apply per pax)). |
+
+:::caution
+**IMPORTANT**: The column order must be exactly as shown: `Rate Code;Charge Type;Type;ApplyType;Value;Is Per Night;Is Per Pax`. Note that **Type** comes before **ApplyType**.
+:::
 
 #### Sheet Format Example
 
@@ -32,21 +36,21 @@ If you have any questions about how to add the requested information to create t
 #### CSV Format Example for Channel Managers
 
 ```
-Rate Code;Charge Type;ApplyType;Value;Type;Is Per Night;Is Per Pax
-"123RATE_TEST";"1";"Amount";"20";"City";"1";"1"
+Rate Code;Charge Type;Type;ApplyType;Value;Is Per Night;Is Per Pax
+"123RATE_TEST";"1";"City";"Amount";"20";"1";"1"
 ```
 ### Additional information
 
 #### ApplyType
 | ApplyType |
 |-------------|
-|PerCent|
+| PerCent |
 | Amount |
 
 #### Type
 | Type |
 |-------------|
-|City|
+| City |
 | Local |
 | Resort Fee |
 | Supplement To Be Paid On Spot |


### PR DESCRIPTION
## Summary

Corrects 6 documentation files in `docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/` that had discrepancies with the actual service implementation (`supply-push-service-setup_loading`).

## Changes

### 🔴 Critical
- **`set-up/taxes.mdx`** — Fixed column order: `ApplyType`, `Type` and `Value` were inverted in the CSV table. The correct order (as per `TaxesFileParser.cs`) is: `HotelCode`, `DateFrom`, `DateTo`, `TaxType`, `Value`, `Type`, `ApplyType`.
- **`quickstart.mdx`** — Fixed polling interval: doc said "10 seconds", real value is ~1 hour (`PollingRetriever` default). Also added a CSV format reference section.
- **`set-up/specific-clients.mdx`** — Entity does not exist in the `Entities` enum. Marked as **NOT SUPPORTED** to prevent confusion.

### 🟡 High
- **`set-up/policies.mdx`** — Documented that NRF (Non-Refundable) policy type supports empty optional fields (`DateFrom`, `DateTo`, `Hour`, `DaysBeforeArrival`), as the parser allows this.
- **`masters/rooms-master.mdx`** — Added the alternative `providerCode` file naming format that the parser accepts.

### 🟢 Medium
- **`set-up/rateplans.mdx`** — Documented that `Commission` column accepts values with `%` suffix (e.g., `15%`) as the parser strips it automatically.

## Root cause

These errors were identified while investigating why client **Restel** could not see their inventory data after uploading CSV files to the SFTP. The incorrect column order in `taxes.mdx` was causing silent parse failures.