### PR TITLE
Update VCC cancellation process details

### DIFF
--- a/kb/faqs/faqs-price/vcc-payments.md
+++ b/kb/faqs/faqs-price/vcc-payments.md
@@ -27,8 +27,8 @@ Our **VCC Generation Plugin** offers key functionalities to streamline virtual c
 
 2. **VccCan - Cancel a Virtual Credit Card**  
    The [VCC Cancel Plugin](/docs/apis/for-buyers/hotel-x-pull-buyers-api/plugins/virtual-credit-card) enables cancellation of a VCC using the ID returned in the Book response. The cancellation status appears in the `paymentInfo` field. Rules in the `genvcc.csv` file can be configured to determine which VCCs should be canceled. More details on this process can be found [here](/docs/apis/for-buyers/hotel-x-pull-buyers-api/plugins/virtual-credit-card#file-format-specification).
-Once a card has been canceled, it is permanently deactivated and cannot be used for any further transactions. For any future operations, a new card must be issued.
-Please note that canceling a booking does not automatically cancel the associated card; it requires an independent API call. However, it can be configured to cancel the card simultaneously with the reservation cancellation.
+   Once a card has been canceled, it is permanently deactivated and cannot be used for any further transactions. For any future operations, a new card must be issued.
+   Please note that canceling a booking does not automatically cancel the associated card; you must cancel it with an independent API call. However, the VCC plugin can be configured to cancel the card simultaneously with the reservation cancellation.
 
 ## Activating VCC Payments with Integrated VCC Suppliers
 

--- a/kb/faqs/faqs-price/vcc-payments.md
+++ b/kb/faqs/faqs-price/vcc-payments.md
@@ -27,6 +27,8 @@ Our **VCC Generation Plugin** offers key functionalities to streamline virtual c
 
 2. **VccCan - Cancel a Virtual Credit Card**  
    The [VCC Cancel Plugin](/docs/apis/for-buyers/hotel-x-pull-buyers-api/plugins/virtual-credit-card) enables cancellation of a VCC using the ID returned in the Book response. The cancellation status appears in the `paymentInfo` field. Rules in the `genvcc.csv` file can be configured to determine which VCCs should be canceled. More details on this process can be found [here](/docs/apis/for-buyers/hotel-x-pull-buyers-api/plugins/virtual-credit-card#file-format-specification).
+Once a card has been canceled, it is permanently deactivated and cannot be used for any further transactions. For any future operations, a new card must be issued.
+Please note that canceling a booking does not automatically cancel the associated card; it requires an independent API call. However, it can be configured to cancel the card simultaneously with the reservation cancellation.
 
 ## Activating VCC Payments with Integrated VCC Suppliers
 


### PR DESCRIPTION
Added information about VCC cancellation permanence and the need for an independent API call to cancel associated cards.