### PR TITLE
fix: Apply correct error codes in content

### DIFF
--- a/docs/apis/for-buyers/deprecated/legacy-pull-buyers-api/making-requests/errors-and-warnings/content.mdx
+++ b/docs/apis/for-buyers/deprecated/legacy-pull-buyers-api/making-requests/errors-and-warnings/content.mdx
@@ -13,4 +13,4 @@ Below is a breakdown of the different errors you may receive on different static
 | 101    | Internal Error. System Exception (Exception not controlled or not classified as general exception).           |
 | 201    | Error retrieving data.                                                                                        |
 | 207    | Request not supported. The required parameter 'HotelXAccessCode' is missing from the configuration parameters.|
-| 302    | Hotel Not Found in DescriptiveInfo.                                                                           |                                                                                              |
+| 302    | Hotel Not Found in DescriptiveInfo.                                                                           |

--- a/docs/apis/for-buyers/deprecated/legacy-pull-buyers-api/making-requests/errors-and-warnings/content.mdx
+++ b/docs/apis/for-buyers/deprecated/legacy-pull-buyers-api/making-requests/errors-and-warnings/content.mdx
@@ -10,5 +10,7 @@ Below is a breakdown of the different errors you may receive on different static
 
 | Code   | Description                                                                                                                                                          |
 | -----  |----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 201  | Error retrieving data.         |
-| 302  | Hotel Not Found in DescriptiveInfo.                                                                                                            |
+| 101    | Internal Error. System Exception (Exception not controlled or not classified as general exception).           |
+| 201    | Error retrieving data.                                                                                        |
+| 207    | Request not supported. The required parameter 'HotelXAccessCode' is missing from the configuration parameters.|
+| 302    | Hotel Not Found in DescriptiveInfo.                                                                           |                                                                                              |

--- a/docs/apis/for-sellers/deprecated/hotel-pull-sellers-api/making-requests/errors-and-warnings/content.mdx
+++ b/docs/apis/for-sellers/deprecated/hotel-pull-sellers-api/making-requests/errors-and-warnings/content.mdx
@@ -11,11 +11,7 @@ Clients are familiar with these types of errors and if they are well categorised
 
 | Code   | Description                                                                                                                                                          |
 | -----  |----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 101  | System Exception (Exception not controlled or not classified as general exception).         |
-| 102  | Supplier Error.                                                                                                                                |
-| 103  | Too many requests to the supplier.                                                                                                             |
-| 104  | Timeout (Timeout during the execution of an operation (look in the common attribute timeout )).                                            |
-| 105  | Communication Error.                                                                                                                           |
-| 206  | The Supplier doesn’t accept the dates RQ.                                                                                                      |
-| 207  | The Supplier doesn’t accept the request RQ.                                                                                                    |
-| 302  | Hotel Not Found in DescriptiveInfo.                                                                                                            |
+| 101    | Internal Error. System Exception (Exception not controlled or not classified as general exception).           |
+| 201    | Error retrieving data.                                                                                        |
+| 207    | Request not supported. The required parameter 'HotelXAccessCode' is missing from the configuration parameters.|
+| 302    | Hotel Not Found in DescriptiveInfo.                                                                           |


### PR DESCRIPTION
The error codes in the static content are being updated.

<img width="1014" height="656" alt="image" src="https://github.com/user-attachments/assets/fbd09d92-1240-4140-8e70-659f2fa6e3cb" />
<img width="992" height="481" alt="image" src="https://github.com/user-attachments/assets/08d8bac0-8438-42c6-af3f-24b2e93de1b2" />
