### PR TITLE
fix(docs): correct broken internal links in Product Load overview

### DIFF
--- a/docs/apis/for-sellers/inventory-push-graphql-api/product-load/overview.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/product-load/overview.mdx
@@ -9,24 +9,24 @@ sidebar_position: 1
     - **Availability Load**: This part deals with loading the availability of your products. It consists of two types: Rates and Offers.
         - **Rates**:
 
-            - **Load Rate Availability** (Mutation): Learn how to load the availability of your rates in the [load-rate-availability](./availability/rates/load-rate-availability) document.
-            - **Retrieve Rate Availability** (Query): Learn how to retrieve the loaded availability of your rates in the [retrieve-rate-availability](./availability/rates/retrieve-rate-availability) document.
+            - **Load Rate Availability** (Mutation): Learn how to load the availability of your rates in the [load-rate-availability](./availability/rates/load-rate-availability.mdx) document.
+            - **Retrieve Rate Availability** (Query): Learn how to retrieve the loaded availability of your rates in the [retrieve-rate-availability](./availability/rates/retrieve-rate-availability.mdx) document.
         - **Offers**:
 
-            - **Load Offers Availability** (Mutation): Learn how to load the availability of your offers in the [load-offers-availability](./availability/offers/load-offers-availability) document.
-            - **Retrieve Offers Availability** (Query): Learn how to retrieve the loaded availability of your offers in the [retrieve-offers-availability](./availability/offers/retrieve-offers-availability) document.
+            - **Load Offers Availability** (Mutation): Learn how to load the availability of your offers in the [load-offers-availability](./availability/offers/load-offers-availability.mdx) document.
+            - **Retrieve Offers Availability** (Query): Learn how to retrieve the loaded availability of your offers in the [retrieve-offers-availability](./availability/offers/retrieve-offers-availability.mdx) document.
 
     - **Pricing Load**: This part deals with loading the pricing information of your products. It consists of two types: Rates and Meal Plan Supplements.
         - **Rates**:
 
-            - **Load Rate Price Per Occupancy** (Mutation): Learn how to load the price per occupancy in the rate in the [load-rate-price-per-occupancy](./price/rates/load-rate-price-per-occupancy) document.
-            - **Load Rate Price Per Room** (Mutation): Learn how to load the price per room in the rate in the [load-rate-price-per-room](./price/rates/load-rate-price-per-room) document.
-            - **Retrieve Rate Price** (Query): Learn how to retrieve the loaded price of your rate in the [retrieve-rate-price](./price/rates/retrieve-rate-price) document.
+            - **Load Rate Price Per Occupancy** (Mutation): Learn how to load the price per occupancy in the rate in the [load-rate-price-per-occupancy](./price/rates/load-rate-price-per-occupancy.mdx) document.
+            - **Load Rate Price Per Room** (Mutation): Learn how to load the price per room in the rate in the [load-rate-price-per-room](./price/rates/load-rate-price-per-room.mdx) document.
+            - **Retrieve Rate Price** (Query): Learn how to retrieve the loaded price of your rate in the [retrieve-rate-price](./price/rates/retrieve-rate-price.mdx) document.
 
         - **Meal Plan Supplements**:
 
-            - **Load Meal Plan Supplements** (Mutation): Learn how to load the supplements of your meal plans in the [load-mealplan-supplements](./price/mealplan-supplements/load-mealplan-supplements-price) document.
-            - **Retrieve Meal Plan Supplements** (Query): Learn how to retrieve the loaded supplements of your meal plans in the [retrieve-mealplan-supplements](./price/mealplan-supplements/retrieve-mealplan-supplements-price) document.
+            - **Load Meal Plan Supplements** (Mutation): Learn how to load the supplements of your meal plans in the [load-mealplan-supplements](./price/mealplan-supplements/load-mealplan-supplements-price.mdx) document.
+            - **Retrieve Meal Plan Supplements** (Query): Learn how to retrieve the loaded supplements of your meal plans in the [retrieve-mealplan-supplements](./price/mealplan-supplements/retrieve-mealplan-supplements-price.mdx) document.
 
 ## Methods
 


### PR DESCRIPTION
The relative links in the Inventory Push GraphQL API Product Load
overview page pointed to paths without the .mdx extension, so Docusaurus
did not resolve them as documents and the browser resolved them against
the page URL, producing broken links.

Add the .mdx extension to all 9 internal links (Availability Rates/Offers
and Pricing Rates/Meal Plan Supplements) so they resolve to the correct
routes, matching the linking convention used across the rest of the docs.

Refs: PUSH-7856