### PR TITLE
docs(push): reference Travelgate fixed IP list in Channel-X and Inventory Push

### DIFF
--- a/docs/apis/for-buyers/channel-x-push-buyers-api/making-requests/endpoint.mdx
+++ b/docs/apis/for-buyers/channel-x-push-buyers-api/making-requests/endpoint.mdx
@@ -9,6 +9,12 @@ In the case of Channel-X, it is the responsibility of the Buyer to provide Trave
 
 Therefore, if you are planning to develop Channel-X, please reach out to Travelgate's onboarding team. In your email, explain that you will be developing Channel-X and provide the endpoint, username and password. With this information, the Onboarding team will configure your account, enabling you to develop and effectively utilize Channel-X.
 
+:::info Travelgate IP addresses
+
+The requests to your endpoint will be sent from a fixed set of Travelgate IP addresses. If your system filters traffic by IP, make sure to allow them. Check the current list in [Travelgate Fixed IP Lists](/kb/welcome-to-travelgate/connectivity-services/how-do-tgx-ips-work-with-sellers#fixed-ip-list-for-inventory-push-or-channelx-buyer).
+
+:::
+
 :::info
 
 For the onboarding team to configure your account, send the email to client-onboarding@travelgate.com.

--- a/docs/apis/for-sellers/inventory-push-graphql-api/booking-management/booking-notification.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/booking-management/booking-notification.mdx
@@ -21,6 +21,13 @@ If you have the booking locator, include it in the `BookNotif` response, this wa
 :::
 
 Keep in mind that if there's an issue with the reservation in your system, we'll consider it as not successful (NOK) and we return an error message.
+
+:::info Travelgate IP addresses
+
+`BookNotif` requests are sent to your endpoint from a fixed set of Travelgate IP addresses. If your system filters traffic by IP, make sure to allow them. Check the current list in [Travelgate Fixed IP Lists](/kb/welcome-to-travelgate/connectivity-services/how-do-tgx-ips-work-with-sellers#fixed-ip-list-for-inventory-push-or-channelx-buyer).
+
+:::
+
 ### 1. Criteria
 
 #### BookNotif Request


### PR DESCRIPTION
Add an info call-out pointing to the Travelgate Fixed IP Lists KB in the
pages where partners expose an endpoint that receives requests from TGX,
so they know which IPs to allow if they filter traffic by IP.

- channel-x endpoint.mdx: call-out on the Buyer endpoint page.
- inventory-push booking-notification.mdx: call-out in the BookNotif overview.

Both call-outs link to the current KB anchor
(#fixed-ip-list-for-inventory-push-or-channelx-buyer), since the anchors
referenced in the ticket are outdated and both cases now share one section.

Refs: PUSH-7892