### PR TITLE
fix(docs): correct set-up mutation names in Inventory GraphQL API docs

### DIFF
--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/hotels-set-up/create-hotel-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/hotels-set-up/create-hotel-set-up.mdx
@@ -10,7 +10,7 @@ import {createHotelSetUpMutation, createHotelSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `createHotelSetUp` mutation allows you to add a new hotel, with its configuration, to a specific client-seller relation in Inventory. The returned fields include:
+The `createHotelSetup` mutation allows you to add a new hotel, with its configuration, to a specific client-seller relation in Inventory. The returned fields include:
 
 * `id`
 * `hotelCode`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/hotels-set-up/delete-hotel-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/hotels-set-up/delete-hotel-set-up.mdx
@@ -10,7 +10,7 @@ import {deleteHotelSetUpMutation, deleteHotelSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `deleteHotelSetUp` mutation is designed to remove a specific hotel from a client-seller relation in Inventory. The returned fields include:
+The `deleteHotelSetup` mutation is designed to remove a specific hotel from a client-seller relation in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/hotels-set-up/update-hotel-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/hotels-set-up/update-hotel-set-up.mdx
@@ -10,7 +10,7 @@ import {updateHotelSetUpMutation, updateHotelSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `updateHotelSetUp` allows you to update a configuration from a hotel already added in a specific client-seller relation in Inventory. The returned fields include:
+The `updateHotelSetup` allows you to update a configuration from a hotel already added in a specific client-seller relation in Inventory. The returned fields include:
 
 * `id`
 * `hotelCode`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/offers-set-up/create-offers-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/offers-set-up/create-offers-set-up.mdx
@@ -10,7 +10,7 @@ import {createOffersSetUpMutation, createOffersSetUpVariables} from "/src/graphq
 
 ## Mutation Overview
 
-The `createOffersSetUp` mutation allows you to create new offers for an existing hotel rate in Inventory. The returned fields include:
+The `createOffersSetup` mutation allows you to create new offers for an existing hotel rate in Inventory. The returned fields include:
 
 * `code`
 * `description`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/offers-set-up/delete-offers-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/offers-set-up/delete-offers-set-up.mdx
@@ -10,7 +10,7 @@ import {deleteOffersSetUpMutation, deleteOffersSetUpVariables} from "/src/graphq
 
 ## Mutation Overview
 
-The `deleteOffersSetUp` mutation is designed to remove offers from hotel rates in Inventory. The returned fields include:
+The `deleteOffersSetup` mutation is designed to remove offers from hotel rates in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/offers-set-up/update-offers-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/offers-set-up/update-offers-set-up.mdx
@@ -10,7 +10,7 @@ import {updateOffersSetUpMutation, updateOffersSetUpVariables} from "/src/graphq
 
 ## Mutation Overview
 
-The `updateOffersSetUp` mutation allows you to update existing offers' properties (except the offer code). The returned fields include:
+The `updateOffersSetup` mutation allows you to update existing offers' properties (except the offer code). The returned fields include:
 
 * `code`
 * `description`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/create-rates-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/create-rates-set-up.mdx
@@ -10,7 +10,7 @@ import {createRatesSetUpMutation, createRatesSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `createRateSetUp` mutation allows you to create new rates for a hotel in a specific client - seller relation in Inventory. The returned fields include:
+The `createRatesSetup` mutation allows you to create new rates for a hotel in a specific client - seller relation in Inventory. The returned fields include:
 
 * `code`
 * `name`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/delete-rates-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/delete-rates-set-up.mdx
@@ -10,7 +10,7 @@ import {deleteRatesSetUpMutation, deleteRatesSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `deleteRatesSetUp` mutation removes hotel rates from a client-seller relation in Inventory. The returned fields include:
+The `deleteRatesSetup` mutation removes hotel rates from a client-seller relation in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/update-rates-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/update-rates-set-up.mdx
@@ -9,7 +9,7 @@ import {updateRatesSetUpMutation, updateRatesSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `updateRatesSetUp` mutation allows you to update any property of an already added rate to a hotel in a specific client-seller relation in Inventory. The returned fields include:
+The `updateRateSetup` mutation allows you to update any property of an already added rate to a hotel in a specific client-seller relation in Inventory. The returned fields include:
 
 * `code`
 * `name`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/create-rooms-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/create-rooms-set-up.mdx
@@ -10,7 +10,7 @@ import {createRoomsSetUpMutation, createRoomsSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `createRoomsSetUp` mutation allows you to create new rooms for an existing hotel rate in Inventory. The returned fields include:
+The `createRoomsSetup` mutation allows you to create new rooms for an existing hotel rate in Inventory. The returned fields include:
 
 * `code`
 * `master`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/delete-rooms-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/delete-rooms-set-up.mdx
@@ -10,7 +10,7 @@ import {deleteRoomsSetUpMutation, deleteRoomsSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `deleteRoomsSetUp` mutation is designed to remove rooms from hotel rates in Inventory. The returned fields include:
+The `deleteRoomsSetup` mutation is designed to remove rooms from hotel rates in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/update-rooms-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/update-rooms-set-up.mdx
@@ -10,7 +10,7 @@ import {updateRoomsSetUpMutation, updateRoomsSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `updateRoomsSetUp` mutation allows you to update existing rooms' properties (except the room code). The returned fields include:
+The `updateRoomsSetup` mutation allows you to update existing rooms' properties (except the room code). The returned fields include:
 
 * `code`
 * `master`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/hotels-set-up/create-hotel-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/hotels-set-up/create-hotel-set-up.mdx
@@ -11,7 +11,7 @@ import {createHotelSetUpMutation, createHotelSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `createHotelSetUp` mutation allows you to add a new hotel, with its configuration, to a specific client-seller relation in Inventory. The returned fields include:
+The `createHotelSetup` mutation allows you to add a new hotel, with its configuration, to a specific client-seller relation in Inventory. The returned fields include:
 
 * `id`
 * `hotelCode`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/hotels-set-up/delete-hotel-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/hotels-set-up/delete-hotel-set-up.mdx
@@ -11,7 +11,7 @@ import {deleteHotelSetUpMutation, deleteHotelSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `deleteHotelSetUp` mutation is designed to remove a specific hotel from a client-seller relation in Inventory. The returned fields include:
+The `deleteHotelSetup` mutation is designed to remove a specific hotel from a client-seller relation in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/hotels-set-up/update-hotel-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/hotels-set-up/update-hotel-set-up.mdx
@@ -12,7 +12,7 @@ import {updateHotelSetUpMutation, updateHotelSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `updateHotelSetUp` allows you to update a configuration from a hotel already added in a specific client-seller relation in Inventory. The returned fields include:
+The `updateHotelSetup` allows you to update a configuration from a hotel already added in a specific client-seller relation in Inventory. The returned fields include:
 
 * `id`
 * `hotelCode`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/offers-set-up/create-offers-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/offers-set-up/create-offers-set-up.mdx
@@ -12,7 +12,7 @@ import {createOffersSetUpMutation, createOffersSetUpVariables} from "/src/graphq
 
 ## Mutation Overview
 
-The `createOffersSetUp` mutation allows you to create new offers for an existing hotel rate in Inventory. The returned fields include:
+The `createOffersSetup` mutation allows you to create new offers for an existing hotel rate in Inventory. The returned fields include:
 
 * `code`
 * `description`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/offers-set-up/delete-offers-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/offers-set-up/delete-offers-set-up.mdx
@@ -11,7 +11,7 @@ import {deleteOffersSetUpMutation, deleteOffersSetUpVariables} from "/src/graphq
 
 ## Mutation Overview
 
-The `deleteOffersSetUp` mutation is designed to remove offers from hotel rates in Inventory. The returned fields include:
+The `deleteOffersSetup` mutation is designed to remove offers from hotel rates in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/offers-set-up/update-offers-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/offers-set-up/update-offers-set-up.mdx
@@ -11,7 +11,7 @@ import {updateOffersSetUpMutation, updateOffersSetUpVariables} from "/src/graphq
 
 ## Mutation Overview
 
-The `updateOffersSetUp` mutation allows you to update existing offers' properties (except the offer code). The returned fields include:
+The `updateOffersSetup` mutation allows you to update existing offers' properties (except the offer code). The returned fields include:
 
 * `code`
 * `description`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rates-set-up/create-rates-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rates-set-up/create-rates-set-up.mdx
@@ -13,7 +13,7 @@ import {createRatesSetUpMutation, createRatesSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `createRateSetUp` mutation allows you to create new rates for a hotel in a specific client - seller relation in Inventory. The returned fields include:
+The `createRatesSetup` mutation allows you to create new rates for a hotel in a specific client - seller relation in Inventory. The returned fields include:
 
 * `code`
 * `name`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rates-set-up/delete-rates-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rates-set-up/delete-rates-set-up.mdx
@@ -12,7 +12,7 @@ import {deleteRatesSetUpMutation, deleteRatesSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `deleteRatesSetUp` mutation removes hotel rates from a client-seller relation in Inventory. The returned fields include:
+The `deleteRatesSetup` mutation removes hotel rates from a client-seller relation in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rates-set-up/update-rates-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rates-set-up/update-rates-set-up.mdx
@@ -8,7 +8,7 @@ import {updateRatesSetUpMutation, updateRatesSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `updateRatesSetUp` mutation allows you to update any property of an already added rate to a hotel in a specific client-seller relation in Inventory. The returned fields include:
+The `updateRateSetup` mutation allows you to update any property of an already added rate to a hotel in a specific client-seller relation in Inventory. The returned fields include:
 
 * `code`
 * `name`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rooms-set-up/create-rooms-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rooms-set-up/create-rooms-set-up.mdx
@@ -11,7 +11,7 @@ import {createRoomsSetUpMutation, createRoomsSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `createRoomsSetUp` mutation allows you to create new rooms for an existing hotel rate in Inventory. The returned fields include:
+The `createRoomsSetup` mutation allows you to create new rooms for an existing hotel rate in Inventory. The returned fields include:
 
 * `code`
 * `master`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rooms-set-up/delete-rooms-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rooms-set-up/delete-rooms-set-up.mdx
@@ -12,7 +12,7 @@ import {deleteRoomsSetUpMutation, deleteRoomsSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `deleteRoomsSetUp` mutation is designed to remove rooms from hotel rates in Inventory. The returned fields include:
+The `deleteRoomsSetup` mutation is designed to remove rooms from hotel rates in Inventory. The returned fields include:
 
 * `success`
 * `adviseMessages`

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rooms-set-up/update-rooms-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/rooms-set-up/update-rooms-set-up.mdx
@@ -12,7 +12,7 @@ import {updateRoomsSetUpMutation, updateRoomsSetUpVariables} from "/src/graphql/
 
 ## Mutation Overview
 
-The `updateRoomsSetUp` mutation allows you to update existing rooms' properties (except the room code). The returned fields include:
+The `updateRoomsSetup` mutation allows you to update existing rooms' properties (except the room code). The returned fields include:
 
 * `code`
 * `master`

--- a/kb/faqs/faqs-cancel-policies/inventory-cancel-policies.md
+++ b/kb/faqs/faqs-cancel-policies/inventory-cancel-policies.md
@@ -52,7 +52,7 @@ After the check-in date, the cancellation cost will be equal to the total value 
 
 ### How are cancellation policies included when creating rates using the Inventory Push GraphQL API?
 
-When using the **Inventory Push GraphQL API** with the `createRatesSetUp` mutation, cancellation policy details are specified within the [input structure](/api/types/inputs/cancel-policies-create-input) of your API call.  
+When using the **Inventory Push GraphQL API** with the `createRatesSetup` mutation, cancellation policy details are specified within the [input structure](/api/types/inputs/cancel-policies-create-input) of your API call.  
 
 You can define both `baseCancelPolicy` and `cancelPoliciesByDate` to cover general and date-specific cancellation rules.
 
@@ -68,7 +68,7 @@ This prevents a rate without cancellation policies from being considered 100% re
 
 ### Can I modify an existing rate’s cancellation policy using the GraphQL API?
 
-Yes, you can update an existing rate’s cancellation policy using the `updateRatesSetUp` mutation in the Inventory Push GraphQL API. This allows you to modify specific fields, such as penalties, without needing to resend the full rate configuration.  
+Yes, you can update an existing rate’s cancellation policy using the `updateRateSetup` mutation in the Inventory Push GraphQL API. This allows you to modify specific fields, such as penalties, without needing to resend the full rate configuration.  
 
 **How it works:** Reference the rate code of the rate you want to update, and include the revised cancellation policy details in the mutation input. These updates will replace the existing cancellation settings for that rate.
 


### PR DESCRIPTION
Align all set-up mutation names in the docs with the GraphQL API
Reference. Beyond the reported missing "s" in createRatesSetup, the
prose used the wrong casing "SetUp" instead of "Setup" across every
set-up mutation (hotels, rooms, rates, offers) in both the for-sellers
and for-buyers documentation trees, plus the cancel-policies FAQ.

Only the prose references were changed; the JS import identifiers
(...SetUpMutation) are left untouched.

Refs: PUSH-8184