### PR TITLE
docs(inventory): add Derived Rates Setup documentation (get/create/update/delete)

### DIFF
--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/_category_.json
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Derived Rates",
+  "position": 4,
+  "link": null
+}

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx
@@ -1,0 +1,104 @@
+---
+sidebar_position: 2
+---
+
+
+
+import DerivedRatesSetupRs from "../../../../../../../src/graphql/generated-docs/DerivedRatesSetupRs.mdx";
+import InventoryDerivedRateSetupCreateInput from "../../../../../../../src/graphql/generated-docs/InventoryDerivedRateSetupCreateInput.mdx";
+
+import {createDerivedRatesSetUpMutation, createDerivedRatesSetUpVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.mutation";
+
+# Create Derived Rates
+
+## Mutation Overview
+
+The `createDerivedRatesSetup` mutation allows you to create a new derived rate for a hotel in a specific client - seller relation in Inventory. A derived rate inherits its configuration from a *base rate* (`baseCode`); for each inheritable section you decide whether to inherit the value from the base rate or to override it with a specific value. The returned fields include:
+
+* `code`
+* `name`
+* `active`
+* `baseCode`
+* `mealPlanIncluded`
+* `paymentPolicies`
+* `inheritAllRoomsBaseRate`
+* `informBaseRate`
+* `inheritMealPlanSupplements`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+* `rate`
+  * `code`
+  * `name`
+  * `active`
+  * `mealPlanIncludedDetails`
+    * `inheritMealPlanIncludedFromBaseRate`
+  * `informBaseRate`
+  * `paymentPolicies`
+    * `inheritFromBaseRate`
+  * `cancelPolicies`
+    * `inheritFromBaseRate`
+  * `roomsDetails`
+    * `inheritAllRoomsBaseRate`
+  * `inheritMealPlanSupplements`
+
+#### Optional Input
+* `contextCode`
+* `rate`
+  * `baseCode`
+  * `bookingRules`
+    * `bookingWindowDetails`
+    * `marketsDetails`
+    * `rateRulesDetails`
+    * `seniorRuleDetails`
+
+### 2. Settings
+
+Ensure that the provided `baseCode` matches an existing rate in your inventory setup, and that the inheritance flags are set according to the values you want to inherit or override.
+
+:::note
+
+Age policies are always inherited from the base rate, so they cannot be overridden when creating a derived rate.
+
+:::
+
+### Response Considerations
+
+The mutation returns the created derived rate details along with success status and possible advise messages.
+
+#### `DerivedRatesSetupRs` (*OBJECT*)
+* `ratesCreated` (*DerivedRateSetup*) - A collection of created derived rates.
+  * `code` (*String*) - The derived rate code.
+  * `name` (*String*) - Name of the derived rate.
+  * `active` (*Boolean*) - Indicates if the derived rate is active.
+  * `baseCode` (*String*) - The base rate code the derived rate inherits from.
+  * `mealPlanIncluded` (*Object*) - Meal plan included, with its resolved value and inheritance flag.
+  * `paymentPolicies` (*Object*) - Payment policies with inheritance metadata.
+  * `inheritAllRoomsBaseRate` (*Boolean*) - Indicates whether all rooms are inherited from the base rate.
+  * `informBaseRate` (*Boolean*) - Indicates if the base rate code is sent to the supplier instead of the derived rate code.
+  * `inheritMealPlanSupplements` (*Boolean*) - Indicates whether meal plan supplements are inherited from the base rate.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+
+## Mutation Inputs
+
+<InventoryDerivedRateSetupCreateInput />
+## Returned Fields
+
+<DerivedRatesSetupRs />
+
+
+## Examples
+
+#### Create a new derived rate
+
+With the following mutation, we are going to create a new derived rate for hotel 2 that inherits its whole configuration from the base rate `BAR`.
+
+<GraphqlSample query={createDerivedRatesSetUpMutation} variables={createDerivedRatesSetUpVariables} />

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 4
+---
+
+
+import DerivedRatesSetupRs from "../../../../../../../src/graphql/generated-docs/DerivedRatesSetupRs.mdx";
+import InventoryDerivedRateSetupDeleteInput from "../../../../../../../src/graphql/generated-docs/InventoryDerivedRateSetupDeleteInput.mdx";
+
+import {deleteDerivedRatesSetUpMutation, deleteDerivedRatesSetUpVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.mutation";
+
+# Delete Derived Rates
+
+## Mutation Overview
+
+The `deleteDerivedRatesSetup` mutation removes derived rates from a hotel in a client-seller relation in Inventory. The returned fields include:
+
+* `ratesDeleted`
+* `success`
+* `adviseMessages`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+* `derivedRateCodes`
+
+#### Optional Input
+* `contextCode`
+
+### 2. Settings
+
+Ensure that the provided derived rate codes correspond to existing derived rates in your inventory setup.
+
+### Response Considerations
+
+The mutation returns the collection of deleted derived rate codes along with success status and potential advise messages regarding the operation.
+
+#### `DerivedRatesSetupRs` (*OBJECT*)
+* `ratesDeleted` (*String*) - A collection of deleted derived rate codes.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+## Mutation Inputs
+
+<InventoryDerivedRateSetupDeleteInput />
+## Returned Fields
+
+<DerivedRatesSetupRs />
+
+
+## Examples
+
+#### Delete a derived rate
+
+<GraphqlSample query={deleteDerivedRatesSetUpMutation} variables={deleteDerivedRatesSetUpVariables} />

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx
@@ -1,0 +1,107 @@
+---
+sidebar_position: 1
+---
+
+
+import InventoryDerivedRatesSetupFilterInput from "../../../../../../../src/graphql/generated-docs/InventoryDerivedRatesSetupFilterInput.mdx";
+import DerivedRatesRs from "../../../../../../../src/graphql/generated-docs/DerivedRatesRs.mdx";
+
+import {derivedRatesSetUpQuery, derivedRatesSetUpVariables, derivedRatesSetUpByBaseCodesVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.query";
+
+
+# Derived Rates
+
+## Query Overview
+
+A **derived rate** is a rate whose configuration is inherited from another rate (its *base rate*). Instead of defining every value from scratch, a derived rate reuses the base rate configuration and only overrides the specific fields you need. Each inheritable field is returned wrapped in an object that exposes both its resolved `value` and an `isInherit` flag indicating whether the value comes from the base rate.
+
+The `derivedRatesSetup` query returns the derived rates added to a hotel for a specific client-seller relation in Inventory. The returned fields include:
+
+* `code`
+* `name`
+* `active`
+* `baseCode`
+* `mealPlanIncluded`
+	* `value`
+	* `isInherit`
+* `inheritedAgePolicies`
+	* `maxAgeChildren`
+	* `maxAgeInfants`
+	* `freeInfants`
+	* `freeChildren`
+* `paymentPolicies`
+	* `inheritedCurrency`
+	* `inheritedCommission`
+	* `inheritedPriceIsBinding`
+	* `acceptedPayments`
+* `bookingRules`
+	* `bookingWindow`
+	* `markets`
+	* `rateRule`
+	* `seniorRule`
+* `cancelPolicies`
+	* `value`
+	* `isInherit`
+* `inheritedSurcharges`
+* `inheritAllRoomsBaseRate`
+* `rooms`
+* `informBaseRate`
+* `inheritMealPlanSupplements`
+
+### 1. Criteria
+
+When building your query, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+
+#### Optional Input
+* `contextCode`
+* `baseRateCodes`
+
+### 2. Settings
+
+Ensure that all required fields are properly set and match existing hotel derived rate configurations.
+
+### Response Considerations
+
+The query returns a collection of derived rates along with success status and possible advise messages.
+
+#### `DerivedRatesRs` (*OBJECT*)
+* `rates` (*DerivedRateSetup*) - A collection of retrieved derived rates.
+  * `code` (*String*) - The derived rate code.
+  * `name` (*String*) - The name of the derived rate.
+  * `active` (*Boolean*) - Indicates if the derived rate is active.
+  * `baseCode` (*String*) - The base rate code the derived rate inherits from.
+  * `mealPlanIncluded` (*Object*) - Meal plan included, with its resolved value and inheritance flag.
+  * `inheritedAgePolicies` (*Object*) - Age policies inherited from the base rate.
+  * `paymentPolicies` (*Object*) - Payment policies with inheritance metadata.
+  * `bookingRules` (*Object*) - Booking window, markets and special rate rules with inheritance metadata.
+  * `cancelPolicies` (*Object*) - Cancel policies with inheritance metadata.
+  * `inheritedSurcharges` (*Object*) - Surcharges inherited from the base rate.
+  * `inheritAllRoomsBaseRate` (*Boolean*) - Indicates whether all rooms are inherited from the base rate.
+  * `rooms` (*Object*) - Rooms associated with the derived rate when they are not inherited.
+  * `informBaseRate` (*Boolean*) - Indicates if the base rate code is sent to the supplier instead of the derived rate code.
+  * `inheritMealPlanSupplements` (*Boolean*) - Indicates whether meal plan supplements are inherited from the base rate.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+## Query Inputs
+
+<InventoryDerivedRatesSetupFilterInput />
+## Returned Fields
+
+<DerivedRatesRs />
+
+
+## Examples
+
+#### Retrieve all derived rates from a hotel
+
+<GraphqlSample query={derivedRatesSetUpQuery} variables={derivedRatesSetUpVariables} />
+
+#### Retrieve derived rates by base rate code
+
+<GraphqlSample query={derivedRatesSetUpQuery} variables={derivedRatesSetUpByBaseCodesVariables} />

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3
+---
+
+
+
+import DerivedRatesSetupRs from "../../../../../../../src/graphql/generated-docs/DerivedRatesSetupRs.mdx";
+import InventoryDerivedRateSetupUpdateInput from "../../../../../../../src/graphql/generated-docs/InventoryDerivedRateSetupUpdateInput.mdx";
+
+import {updateDerivedRatesSetUpMutation, updateDerivedRatesSetUpVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.mutation";
+
+# Update Derived Rates
+
+## Mutation Overview
+
+The `updateDerivedRatesSetup` mutation allows you to update an existing derived rate for a hotel in a specific client - seller relation in Inventory. You only need to send the fields you want to change; any inheritance flag you provide overrides the previous inheritance behaviour for that section. The returned fields include:
+
+* `code`
+* `name`
+* `active`
+* `baseCode`
+* `mealPlanIncluded`
+* `informBaseRate`
+* `inheritMealPlanSupplements`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+* `rate`
+  * `code`
+
+#### Optional Input
+* `contextCode`
+* `rate`
+  * `name`
+  * `active`
+  * `mealPlanIncludedDetails`
+  * `informBaseRate`
+  * `paymentPolicies`
+  * `bookingRules`
+  * `cancelPolicies`
+  * `baseCode`
+  * `roomsDetails`
+  * `inheritMealPlanSupplements`
+
+### 2. Settings
+
+Ensure that the derived rate `code` corresponds to an existing derived rate in your inventory setup. Only the sections you include in the mutation are modified.
+
+:::note
+
+For cancel policies, the `isPartialUpdate` flag determines whether the new policies are added (`true`) or replace the existing ones (`false`).
+
+:::
+
+### Response Considerations
+
+The mutation returns the updated derived rate details along with success status and possible advise messages.
+
+#### `DerivedRatesSetupRs` (*OBJECT*)
+* `ratesUpdated` (*DerivedRateSetup*) - A collection of updated derived rates.
+  * `code` (*String*) - The derived rate code.
+  * `name` (*String*) - Name of the derived rate.
+  * `active` (*Boolean*) - Indicates if the derived rate is active.
+  * `baseCode` (*String*) - The base rate code the derived rate inherits from.
+  * `mealPlanIncluded` (*Object*) - Meal plan included, with its resolved value and inheritance flag.
+  * `informBaseRate` (*Boolean*) - Indicates if the base rate code is sent to the supplier instead of the derived rate code.
+  * `inheritMealPlanSupplements` (*Boolean*) - Indicates whether meal plan supplements are inherited from the base rate.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+
+## Mutation Inputs
+
+<InventoryDerivedRateSetupUpdateInput />
+## Returned Fields
+
+<DerivedRatesSetupRs />
+
+
+## Examples
+
+#### Update a derived rate
+
+With the following mutation, we are going to stop inheriting the meal plan and payment policies from the base rate and set specific values for the derived rate `BAR-DERIVED`.
+
+<GraphqlSample query={updateDerivedRatesSetUpMutation} variables={updateDerivedRatesSetUpVariables} />

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/_category_.json
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Derived Rates",
+  "position": 4,
+  "link": null
+}

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx
@@ -1,0 +1,104 @@
+---
+sidebar_position: 2
+---
+
+
+
+import DerivedRatesSetupRs from "../../../../../../src/graphql/generated-docs/DerivedRatesSetupRs.mdx";
+import InventoryDerivedRateSetupCreateInput from "../../../../../../src/graphql/generated-docs/InventoryDerivedRateSetupCreateInput.mdx";
+
+import {createDerivedRatesSetUpMutation, createDerivedRatesSetUpVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.mutation";
+
+# Create Derived Rates
+
+## Mutation Overview
+
+The `createDerivedRatesSetup` mutation allows you to create a new derived rate for a hotel in a specific client - seller relation in Inventory. A derived rate inherits its configuration from a *base rate* (`baseCode`); for each inheritable section you decide whether to inherit the value from the base rate or to override it with a specific value. The returned fields include:
+
+* `code`
+* `name`
+* `active`
+* `baseCode`
+* `mealPlanIncluded`
+* `paymentPolicies`
+* `inheritAllRoomsBaseRate`
+* `informBaseRate`
+* `inheritMealPlanSupplements`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+* `rate`
+  * `code`
+  * `name`
+  * `active`
+  * `mealPlanIncludedDetails`
+    * `inheritMealPlanIncludedFromBaseRate`
+  * `informBaseRate`
+  * `paymentPolicies`
+    * `inheritFromBaseRate`
+  * `cancelPolicies`
+    * `inheritFromBaseRate`
+  * `roomsDetails`
+    * `inheritAllRoomsBaseRate`
+  * `inheritMealPlanSupplements`
+
+#### Optional Input
+* `contextCode`
+* `rate`
+  * `baseCode`
+  * `bookingRules`
+    * `bookingWindowDetails`
+    * `marketsDetails`
+    * `rateRulesDetails`
+    * `seniorRuleDetails`
+
+### 2. Settings
+
+Ensure that the provided `baseCode` matches an existing rate in your inventory setup, and that the inheritance flags are set according to the values you want to inherit or override.
+
+:::note
+
+Age policies are always inherited from the base rate, so they cannot be overridden when creating a derived rate.
+
+:::
+
+### Response Considerations
+
+The mutation returns the created derived rate details along with success status and possible advise messages.
+
+#### `DerivedRatesSetupRs` (*OBJECT*)
+* `ratesCreated` (*DerivedRateSetup*) - A collection of created derived rates.
+  * `code` (*String*) - The derived rate code.
+  * `name` (*String*) - Name of the derived rate.
+  * `active` (*Boolean*) - Indicates if the derived rate is active.
+  * `baseCode` (*String*) - The base rate code the derived rate inherits from.
+  * `mealPlanIncluded` (*Object*) - Meal plan included, with its resolved value and inheritance flag.
+  * `paymentPolicies` (*Object*) - Payment policies with inheritance metadata.
+  * `inheritAllRoomsBaseRate` (*Boolean*) - Indicates whether all rooms are inherited from the base rate.
+  * `informBaseRate` (*Boolean*) - Indicates if the base rate code is sent to the supplier instead of the derived rate code.
+  * `inheritMealPlanSupplements` (*Boolean*) - Indicates whether meal plan supplements are inherited from the base rate.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+
+## Mutation Inputs
+
+<InventoryDerivedRateSetupCreateInput />
+## Returned Fields
+
+<DerivedRatesSetupRs />
+
+
+## Examples
+
+#### Create a new derived rate
+
+With the following mutation, we are going to create a new derived rate for hotel 2 that inherits its whole configuration from the base rate `BAR`.
+
+<GraphqlSample query={createDerivedRatesSetUpMutation} variables={createDerivedRatesSetUpVariables} />

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 4
+---
+
+
+import DerivedRatesSetupRs from "../../../../../../src/graphql/generated-docs/DerivedRatesSetupRs.mdx";
+import InventoryDerivedRateSetupDeleteInput from "../../../../../../src/graphql/generated-docs/InventoryDerivedRateSetupDeleteInput.mdx";
+
+import {deleteDerivedRatesSetUpMutation, deleteDerivedRatesSetUpVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.mutation";
+
+# Delete Derived Rates
+
+## Mutation Overview
+
+The `deleteDerivedRatesSetup` mutation removes derived rates from a hotel in a client-seller relation in Inventory. The returned fields include:
+
+* `ratesDeleted`
+* `success`
+* `adviseMessages`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+* `derivedRateCodes`
+
+#### Optional Input
+* `contextCode`
+
+### 2. Settings
+
+Ensure that the provided derived rate codes correspond to existing derived rates in your inventory setup.
+
+### Response Considerations
+
+The mutation returns the collection of deleted derived rate codes along with success status and potential advise messages regarding the operation.
+
+#### `DerivedRatesSetupRs` (*OBJECT*)
+* `ratesDeleted` (*String*) - A collection of deleted derived rate codes.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+## Mutation Inputs
+
+<InventoryDerivedRateSetupDeleteInput />
+## Returned Fields
+
+<DerivedRatesSetupRs />
+
+
+## Examples
+
+#### Delete a derived rate
+
+<GraphqlSample query={deleteDerivedRatesSetUpMutation} variables={deleteDerivedRatesSetUpVariables} />

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx
@@ -1,0 +1,107 @@
+---
+sidebar_position: 1
+---
+
+
+import InventoryDerivedRatesSetupFilterInput from "../../../../../../src/graphql/generated-docs/InventoryDerivedRatesSetupFilterInput.mdx";
+import DerivedRatesRs from "../../../../../../src/graphql/generated-docs/DerivedRatesRs.mdx";
+
+import {derivedRatesSetUpQuery, derivedRatesSetUpVariables, derivedRatesSetUpByBaseCodesVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.query";
+
+
+# Derived Rates
+
+## Query Overview
+
+A **derived rate** is a rate whose configuration is inherited from another rate (its *base rate*). Instead of defining every value from scratch, a derived rate reuses the base rate configuration and only overrides the specific fields you need. Each inheritable field is returned wrapped in an object that exposes both its resolved `value` and an `isInherit` flag indicating whether the value comes from the base rate.
+
+The `derivedRatesSetup` query returns the derived rates added to a hotel for a specific client-seller relation in Inventory. The returned fields include:
+
+* `code`
+* `name`
+* `active`
+* `baseCode`
+* `mealPlanIncluded`
+	* `value`
+	* `isInherit`
+* `inheritedAgePolicies`
+	* `maxAgeChildren`
+	* `maxAgeInfants`
+	* `freeInfants`
+	* `freeChildren`
+* `paymentPolicies`
+	* `inheritedCurrency`
+	* `inheritedCommission`
+	* `inheritedPriceIsBinding`
+	* `acceptedPayments`
+* `bookingRules`
+	* `bookingWindow`
+	* `markets`
+	* `rateRule`
+	* `seniorRule`
+* `cancelPolicies`
+	* `value`
+	* `isInherit`
+* `inheritedSurcharges`
+* `inheritAllRoomsBaseRate`
+* `rooms`
+* `informBaseRate`
+* `inheritMealPlanSupplements`
+
+### 1. Criteria
+
+When building your query, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+
+#### Optional Input
+* `contextCode`
+* `baseRateCodes`
+
+### 2. Settings
+
+Ensure that all required fields are properly set and match existing hotel derived rate configurations.
+
+### Response Considerations
+
+The query returns a collection of derived rates along with success status and possible advise messages.
+
+#### `DerivedRatesRs` (*OBJECT*)
+* `rates` (*DerivedRateSetup*) - A collection of retrieved derived rates.
+  * `code` (*String*) - The derived rate code.
+  * `name` (*String*) - The name of the derived rate.
+  * `active` (*Boolean*) - Indicates if the derived rate is active.
+  * `baseCode` (*String*) - The base rate code the derived rate inherits from.
+  * `mealPlanIncluded` (*Object*) - Meal plan included, with its resolved value and inheritance flag.
+  * `inheritedAgePolicies` (*Object*) - Age policies inherited from the base rate.
+  * `paymentPolicies` (*Object*) - Payment policies with inheritance metadata.
+  * `bookingRules` (*Object*) - Booking window, markets and special rate rules with inheritance metadata.
+  * `cancelPolicies` (*Object*) - Cancel policies with inheritance metadata.
+  * `inheritedSurcharges` (*Object*) - Surcharges inherited from the base rate.
+  * `inheritAllRoomsBaseRate` (*Boolean*) - Indicates whether all rooms are inherited from the base rate.
+  * `rooms` (*Object*) - Rooms associated with the derived rate when they are not inherited.
+  * `informBaseRate` (*Boolean*) - Indicates if the base rate code is sent to the supplier instead of the derived rate code.
+  * `inheritMealPlanSupplements` (*Boolean*) - Indicates whether meal plan supplements are inherited from the base rate.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+## Query Inputs
+
+<InventoryDerivedRatesSetupFilterInput />
+## Returned Fields
+
+<DerivedRatesRs />
+
+
+## Examples
+
+#### Retrieve all derived rates from a hotel
+
+<GraphqlSample query={derivedRatesSetUpQuery} variables={derivedRatesSetUpVariables} />
+
+#### Retrieve derived rates by base rate code
+
+<GraphqlSample query={derivedRatesSetUpQuery} variables={derivedRatesSetUpByBaseCodesVariables} />

--- a/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3
+---
+
+
+
+import DerivedRatesSetupRs from "../../../../../../src/graphql/generated-docs/DerivedRatesSetupRs.mdx";
+import InventoryDerivedRateSetupUpdateInput from "../../../../../../src/graphql/generated-docs/InventoryDerivedRateSetupUpdateInput.mdx";
+
+import {updateDerivedRatesSetUpMutation, updateDerivedRatesSetUpVariables} from "/src/graphql/inventory/set-up/derived-rates-set-up.mutation";
+
+# Update Derived Rates
+
+## Mutation Overview
+
+The `updateDerivedRatesSetup` mutation allows you to update an existing derived rate for a hotel in a specific client - seller relation in Inventory. You only need to send the fields you want to change; any inheritance flag you provide overrides the previous inheritance behaviour for that section. The returned fields include:
+
+* `code`
+* `name`
+* `active`
+* `baseCode`
+* `mealPlanIncluded`
+* `informBaseRate`
+* `inheritMealPlanSupplements`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields:
+
+#### Mandatory Input
+* `clientCode`
+* `supplierCode`
+* `hotelCode`
+* `rate`
+  * `code`
+
+#### Optional Input
+* `contextCode`
+* `rate`
+  * `name`
+  * `active`
+  * `mealPlanIncludedDetails`
+  * `informBaseRate`
+  * `paymentPolicies`
+  * `bookingRules`
+  * `cancelPolicies`
+  * `baseCode`
+  * `roomsDetails`
+  * `inheritMealPlanSupplements`
+
+### 2. Settings
+
+Ensure that the derived rate `code` corresponds to an existing derived rate in your inventory setup. Only the sections you include in the mutation are modified.
+
+:::note
+
+For cancel policies, the `isPartialUpdate` flag determines whether the new policies are added (`true`) or replace the existing ones (`false`).
+
+:::
+
+### Response Considerations
+
+The mutation returns the updated derived rate details along with success status and possible advise messages.
+
+#### `DerivedRatesSetupRs` (*OBJECT*)
+* `ratesUpdated` (*DerivedRateSetup*) - A collection of updated derived rates.
+  * `code` (*String*) - The derived rate code.
+  * `name` (*String*) - Name of the derived rate.
+  * `active` (*Boolean*) - Indicates if the derived rate is active.
+  * `baseCode` (*String*) - The base rate code the derived rate inherits from.
+  * `mealPlanIncluded` (*Object*) - Meal plan included, with its resolved value and inheritance flag.
+  * `informBaseRate` (*Boolean*) - Indicates if the base rate code is sent to the supplier instead of the derived rate code.
+  * `inheritMealPlanSupplements` (*Boolean*) - Indicates whether meal plan supplements are inherited from the base rate.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+
+## Mutation Inputs
+
+<InventoryDerivedRateSetupUpdateInput />
+## Returned Fields
+
+<DerivedRatesSetupRs />
+
+
+## Examples
+
+#### Update a derived rate
+
+With the following mutation, we are going to stop inheriting the meal plan and payment policies from the base rate and set specific values for the derived rate `BAR-DERIVED`.
+
+<GraphqlSample query={updateDerivedRatesSetUpMutation} variables={updateDerivedRatesSetUpVariables} />

--- a/src/graphql/generated-docs/DerivedRatesRs.mdx
+++ b/src/graphql/generated-docs/DerivedRatesRs.mdx
@@ -1,0 +1,733 @@
+
+<details>
+  <summary>
+  **DerivedRatesRs** (*OBJECT*)  
+  Represents the response object for derived rates setup operations.  
+  </summary>
+  
+  
+  <details>
+    <summary>
+      <strong>adviseMessages</strong> <em>(AdviseMessage)</em>
+    </summary>
+    Collection of advise messages.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>code</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(ID)</em>
+      </summary>
+      AM code: The following codes can be returned:
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>description</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+      </summary>
+      Error description
+    </details>
+
+    <details open>
+      <summary>
+        <strong>level</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(AdviseMessageLevel)</em>
+      </summary>
+      Indicates the level of importance of the message.
+      Possible values: ERROR, WARN, INFO.
+      <strong>Possible values:</strong>
+      <ul>
+        <li><code>WARN</code>: Warning message.</li>
+        <li><code>ERROR</code>: Error message.</li>
+        <li><code>INFO</code>: Info message.</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary>
+        <strong>external</strong> <em>(ExternalMessage)</em>
+      </summary>
+      Specify the external message.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>code</strong> <em>(String)</em>
+        </summary>
+        External code.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>message</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+        </summary>
+        External message.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>correlationID</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(ID)</em>
+      </summary>
+      Identifier to investigate the cause of the error.
+    </details>
+  </details>
+
+  <details>
+    <summary>
+      <strong>rates</strong> <em>(DerivedRateSetup)</em>
+    </summary>
+    Collection of derived rate setup objects.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>code</strong> <em>(String)</em>
+      </summary>
+      Code associated with the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>name</strong> <em>(String)</em>
+      </summary>
+      Name of the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>active</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether the derived rate is active.
+    </details>
+
+    <details>
+      <summary>
+        <strong>mealPlanIncluded</strong> <em>(InventoryDerivedInt)</em>
+      </summary>
+      Indicates the meal plan included in the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>value</strong> <em>(Int)</em>
+        </summary>
+        The derived value.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the value is inherited from the base rate.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>baseCode</strong> <em>(String)</em>
+      </summary>
+      Base rate code associated with the derived rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>inheritedAgePolicies</strong> <em>(InventoryAgePolicies)</em>
+      </summary>
+      Age policies inherited from the base rate. Age policies are always inherited from the base rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>maxAgeInfants</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Max age baby not inclusive
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>freeInfants</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        If true the babies are free of charge
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>maxAgeChildren</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Max age child not inclusive
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>freeChildren</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        If true children are free of charge
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>paymentPolicies</strong> <em>(InventoryDerivedPaymentPolicies)</em>
+      </summary>
+      Payment policies associated with the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedCurrency</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Currency)</em>
+        </summary>
+        Currency inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedCommission</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+        </summary>
+        Commission inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedPriceIsBinding</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the inherited prices are binding.
+      </details>
+
+      <details>
+        <summary>
+          <strong>acceptedPayments</strong> <em>(InventoryDerivedAcceptedPayments)</em>
+        </summary>
+        Accepted payment methods with inheritance metadata.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(AcceptedPayment)</em>
+          </summary>
+          The derived value.
+
+          <details open>
+            <summary>
+              <strong>type</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PaymentType)</em>
+            </summary>
+
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>MERCHANT</code>: Payment is managed by the supplier.</li>
+              <li><code>DIRECT</code>: Payment is made directly to the actual payee (e.g., the hotel), without involving an intermediary or third party. The payment will be completed at check-in.</li>
+              <li><code>CARD_BOOKING</code>: Payment is managed by the supplier. The payment is effectuated at the time of booking.</li>
+              <li><code>CARD_CHECK_IN</code>: Payment is managed by the supplier and is made at the hotel during check-in.</li>
+            </ul>
+          </details>
+
+          <details open>
+            <summary>
+              <strong>cardTypes</strong> <em>(PaymentCardType)</em>
+            </summary>
+
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>VI</code>: Visa</li>
+              <li><code>AX</code>: American Express</li>
+              <li><code>BC</code>: BC Card</li>
+              <li><code>CA</code>: MasterCard</li>
+              <li><code>CB</code>: Carte Blanche</li>
+              <li><code>CU</code>: China Union Pay</li>
+              <li><code>DS</code>: Discover</li>
+              <li><code>DC</code>: Diners Club</li>
+              <li><code>T</code>: Carta Si</li>
+              <li><code>R</code>: Carte Bleue</li>
+              <li><code>N</code>: Dankort</li>
+              <li><code>L</code>: Delta</li>
+              <li><code>E</code>: Electron</li>
+              <li><code>JC</code>: Japan Credit Bureau</li>
+              <li><code>TO</code>: Maestro</li>
+              <li><code>S</code>: Switch</li>
+              <li><code>EC</code>: Electronic Cash</li>
+              <li><code>EU</code>: EuroCard</li>
+              <li><code>TP</code>: universal air travel card</li>
+              <li><code>OP</code>: optima</li>
+              <li><code>ER</code>: Air Canada/RnRoute</li>
+              <li><code>XS</code>: access</li>
+              <li><code>O</code>: others</li>
+            </ul>
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>bookingRules</strong> <em>(InventoryDerivedBookingRules)</em>
+      </summary>
+      Booking rules associated with the derived rate.
+
+      <details>
+        <summary>
+          <strong>bookingWindow</strong> <em>(InventoryDerivedBookingWindow)</em>
+        </summary>
+        Booking Dates for which the rate will be available. Do not send it if you want the rate available for all dates.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(InventoryBookingWindow)</em>
+          </summary>
+          The derived value.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date of the booking window.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date of the booking window.
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>markets</strong> <em>(InventoryDerivedMarkets)</em>
+        </summary>
+        Markets included or excluded. Do not send if the rate is available for all markets. Only informative.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(InventoryMarkets)</em>
+          </summary>
+          The derived value.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>included</strong> <em>(String)</em>
+            </summary>
+            Included markets.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>excluded</strong> <em>(String)</em>
+            </summary>
+            Excluded markets.
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>rateRule</strong> <em>(InventoryDerivedRateRule)</em>
+        </summary>
+        Rate rule for the derived rate.
+
+        <details open>
+          <summary>
+            <strong>value</strong> <em>(RatePlanType)</em>
+          </summary>
+          The derived value.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_RATE_PLAN_TYPE</code></li>
+            <li><code>LARGE_FAMILY</code></li>
+            <li><code>PUBLIC_SERVANT</code></li>
+            <li><code>NEGOTIATED</code></li>
+            <li><code>PACKAGE</code></li>
+            <li><code>CANARY_RESIDENT</code></li>
+            <li><code>BALEARIC_RESIDENT</code></li>
+            <li><code>HONEY_MOON</code></li>
+          </ul>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>seniorRule</strong> <em>(InventoryDerivedSeniorRule)</em>
+        </summary>
+        Senior rule for the derived rate.
+
+        <details open>
+          <summary>
+            <strong>value</strong> <em>(SeniorRate)</em>
+          </summary>
+          The derived value.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_SENIOR_RATE</code></li>
+            <li><code>SENIOR_RATE_55</code></li>
+            <li><code>SENIOR_RATE_60</code></li>
+            <li><code>SENIOR_RATE_65</code></li>
+          </ul>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>cancelPolicies</strong> <em>(InventoryDerivedCancelPoliciesRate)</em>
+      </summary>
+      Cancel policies associated with the derived rate.
+
+      <details>
+        <summary>
+          <strong>value</strong> <em>(InventoryCancelPoliciesRate)</em>
+        </summary>
+        The derived value.
+
+        <details>
+          <summary>
+            <strong>baseCancelPolicy</strong> <em>(InventoryCancelPolicy)</em>
+          </summary>
+          Defines the base cancel policies. Only Informative.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+            </summary>
+            Indicates if the rate is refundable.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPenalties</strong> <em>(InventoryCancelPenalty)</em>
+            </summary>
+            List of penalties applicable for the rate. See CancelPenalty.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+              </summary>
+              Number of days prior to arrival day in which this Cancellation policy applies.
+            </details>
+
+            <details open>
+              <summary>
+                <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+              </summary>
+              Penalty type. See PenaltyType.
+              <strong>Possible values:</strong>
+              <ul>
+                <li><code>AMOUNT</code></li>
+                <li><code>NIGHTS</code></li>
+                <li><code>PERCENTAGE</code></li>
+              </ul>
+            </details>
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+              </summary>
+              Penalty value.
+            </details>
+          </details>
+        </details>
+
+        <details>
+          <summary>
+            <strong>cancelPoliciesByDate</strong> <em>(InventoryCancelPolicyByDate)</em>
+          </summary>
+          This defines a calendar of cancel policies, serving as informational data. If base cancel policies exist for a particular day, the CancelPoliciesByDate take precedence.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date where the cancel policy must apply.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date where the cancel policy must apply.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPolicy</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryCancelPolicy)</em>
+            </summary>
+            Cancel policy. See CancelPolicy.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+              </summary>
+              Indicates if the rate is refundable.
+            </details>
+
+            <details>
+              <summary>
+                <strong>cancelPenalties</strong> <em>(InventoryCancelPenalty)</em>
+              </summary>
+              List of penalties applicable for the rate. See CancelPenalty.
+
+              <details style={{ pointerEvents: "none" }}>
+                <summary>
+                  <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+                </summary>
+                Number of days prior to arrival day in which this Cancellation policy applies.
+              </details>
+
+              <details open>
+                <summary>
+                  <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+                </summary>
+                Penalty type. See PenaltyType.
+                <strong>Possible values:</strong>
+                <ul>
+                  <li><code>AMOUNT</code></li>
+                  <li><code>NIGHTS</code></li>
+                  <li><code>PERCENTAGE</code></li>
+                </ul>
+              </details>
+
+              <details style={{ pointerEvents: "none" }}>
+                <summary>
+                  <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+                </summary>
+                Penalty value.
+              </details>
+            </details>
+          </details>
+        </details>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the value is inherited from the base rate.
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>inheritedSurcharges</strong> <em>(InventorySurcharge)</em>
+      </summary>
+      Surcharges inherited from the base rate.
+
+      <details open>
+        <summary>
+          <strong>chargeType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryChargeType)</em>
+        </summary>
+        Indicates if the surcharge is included or not in the price.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>INCLUDED</code></li>
+          <li><code>EXCLUDED</code></li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>
+          <strong>taxType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryTaxType)</em>
+        </summary>
+        The type of tax applied to the surcharge.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>CITY</code>: The tax is a city tax.</li>
+          <li><code>LOCAL</code>: The tax is a local tax.</li>
+          <li><code>RESORT_FEE</code>: The tax is a resort fee.</li>
+          <li><code>SUPPLEMENT_TO_BE_PAID_ON_SPOT</code>: The tax is a supplement to be paid on spot.</li>
+        </ul>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+        </summary>
+        The value of the surcharge.
+      </details>
+
+      <details open>
+        <summary>
+          <strong>applyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryApplyType)</em>
+        </summary>
+        The type of application for the surcharge.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>PERCENTAGE</code>: The rate is applied as a percentage.</li>
+          <li><code>AMOUNT</code>: The rate is applied as an amount.</li>
+        </ul>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>perNight</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the surcharge is applied per night.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>perPax</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the surcharge is applied per person.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritAllRoomsBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether all rooms are inherited from the base rate for the derived rate.
+      If true, all rooms from the base rate are inherited. If false, only specific rooms are associated with the derived rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>rooms</strong> <em>(InventoryRoomSetUp)</em>
+      </summary>
+      Rooms associated with the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>code</strong> <em>(String)</em>
+        </summary>
+        Code associated with the room.
+      </details>
+
+      <details>
+        <summary>
+          <strong>master</strong> <em>(InventoryMasterRoom)</em>
+        </summary>
+        Master of the room.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>id</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Id associated with the room master.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>code</strong> <em>(String)</em>
+          </summary>
+          Code associated with the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>name</strong> <em>(String)</em>
+          </summary>
+          Name associated with the room.
+        </details>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>active</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the room is active.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>externalCode</strong> <em>(String)</em>
+        </summary>
+        External code associated with the room.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>standard</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Standard of the room. Typically the number of guests.
+      </details>
+
+      <details>
+        <summary>
+          <strong>uses</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryRoomUse)</em>
+        </summary>
+        List of uses associated with the room.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>numberOfGuests</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the number of guests allowed in the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>minAge</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the minimum age allowed for guests in the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>maxAge</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the maximum age allowed for guests in the room.
+        </details>
+
+        <details open>
+          <summary>
+            <strong>paxType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryPaxType)</em>
+          </summary>
+          Gets or sets the type of guests allowed in the room.
+          PaxType
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>INFANT</code>: Represents an infant guest.</li>
+            <li><code>CHILD</code>: Represents a child guest.</li>
+            <li><code>ADULT</code>: Represents an adult guest.</li>
+          </ul>
+        </details>
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>informBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates if the base rate code has to be sent to the supplier instead of the derived rate code.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritMealPlanSupplements</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether to inherit meal plan supplements from the base rate.
+    </details>
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>success</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+    </summary>
+    Indicates whether the operation was successful based on the absence of advise messages.
+  </details>
+</details>

--- a/src/graphql/generated-docs/DerivedRatesSetupRs.mdx
+++ b/src/graphql/generated-docs/DerivedRatesSetupRs.mdx
@@ -1,0 +1,1395 @@
+
+<details>
+  <summary>
+  **DerivedRatesSetupRs** (*OBJECT*)  
+  Represents the response object for derived rates setup operations.  
+  </summary>
+  
+  
+  <details>
+    <summary>
+      <strong>adviseMessages</strong> <em>(AdviseMessage)</em>
+    </summary>
+    Collection of advise messages.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>code</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(ID)</em>
+      </summary>
+      AM code: The following codes can be returned:
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>description</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+      </summary>
+      Error description
+    </details>
+
+    <details open>
+      <summary>
+        <strong>level</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(AdviseMessageLevel)</em>
+      </summary>
+      Indicates the level of importance of the message.
+      Possible values: ERROR, WARN, INFO.
+      <strong>Possible values:</strong>
+      <ul>
+        <li><code>WARN</code>: Warning message.</li>
+        <li><code>ERROR</code>: Error message.</li>
+        <li><code>INFO</code>: Info message.</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary>
+        <strong>external</strong> <em>(ExternalMessage)</em>
+      </summary>
+      Specify the external message.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>code</strong> <em>(String)</em>
+        </summary>
+        External code.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>message</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+        </summary>
+        External message.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>correlationID</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(ID)</em>
+      </summary>
+      Identifier to investigate the cause of the error.
+    </details>
+  </details>
+
+  <details>
+    <summary>
+      <strong>ratesCreated</strong> <em>(DerivedRateSetup)</em>
+    </summary>
+    Collection of created derived rate setup objects.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>code</strong> <em>(String)</em>
+      </summary>
+      Code associated with the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>name</strong> <em>(String)</em>
+      </summary>
+      Name of the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>active</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether the derived rate is active.
+    </details>
+
+    <details>
+      <summary>
+        <strong>mealPlanIncluded</strong> <em>(InventoryDerivedInt)</em>
+      </summary>
+      Indicates the meal plan included in the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>value</strong> <em>(Int)</em>
+        </summary>
+        The derived value.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the value is inherited from the base rate.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>baseCode</strong> <em>(String)</em>
+      </summary>
+      Base rate code associated with the derived rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>inheritedAgePolicies</strong> <em>(InventoryAgePolicies)</em>
+      </summary>
+      Age policies inherited from the base rate. Age policies are always inherited from the base rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>maxAgeInfants</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Max age baby not inclusive
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>freeInfants</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        If true the babies are free of charge
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>maxAgeChildren</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Max age child not inclusive
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>freeChildren</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        If true children are free of charge
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>paymentPolicies</strong> <em>(InventoryDerivedPaymentPolicies)</em>
+      </summary>
+      Payment policies associated with the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedCurrency</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Currency)</em>
+        </summary>
+        Currency inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedCommission</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+        </summary>
+        Commission inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedPriceIsBinding</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the inherited prices are binding.
+      </details>
+
+      <details>
+        <summary>
+          <strong>acceptedPayments</strong> <em>(InventoryDerivedAcceptedPayments)</em>
+        </summary>
+        Accepted payment methods with inheritance metadata.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(AcceptedPayment)</em>
+          </summary>
+          The derived value.
+
+          <details open>
+            <summary>
+              <strong>type</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PaymentType)</em>
+            </summary>
+
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>MERCHANT</code>: Payment is managed by the supplier.</li>
+              <li><code>DIRECT</code>: Payment is made directly to the actual payee (e.g., the hotel), without involving an intermediary or third party. The payment will be completed at check-in.</li>
+              <li><code>CARD_BOOKING</code>: Payment is managed by the supplier. The payment is effectuated at the time of booking.</li>
+              <li><code>CARD_CHECK_IN</code>: Payment is managed by the supplier and is made at the hotel during check-in.</li>
+            </ul>
+          </details>
+
+          <details open>
+            <summary>
+              <strong>cardTypes</strong> <em>(PaymentCardType)</em>
+            </summary>
+
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>VI</code>: Visa</li>
+              <li><code>AX</code>: American Express</li>
+              <li><code>BC</code>: BC Card</li>
+              <li><code>CA</code>: MasterCard</li>
+              <li><code>CB</code>: Carte Blanche</li>
+              <li><code>CU</code>: China Union Pay</li>
+              <li><code>DS</code>: Discover</li>
+              <li><code>DC</code>: Diners Club</li>
+              <li><code>T</code>: Carta Si</li>
+              <li><code>R</code>: Carte Bleue</li>
+              <li><code>N</code>: Dankort</li>
+              <li><code>L</code>: Delta</li>
+              <li><code>E</code>: Electron</li>
+              <li><code>JC</code>: Japan Credit Bureau</li>
+              <li><code>TO</code>: Maestro</li>
+              <li><code>S</code>: Switch</li>
+              <li><code>EC</code>: Electronic Cash</li>
+              <li><code>EU</code>: EuroCard</li>
+              <li><code>TP</code>: universal air travel card</li>
+              <li><code>OP</code>: optima</li>
+              <li><code>ER</code>: Air Canada/RnRoute</li>
+              <li><code>XS</code>: access</li>
+              <li><code>O</code>: others</li>
+            </ul>
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>bookingRules</strong> <em>(InventoryDerivedBookingRules)</em>
+      </summary>
+      Booking rules associated with the derived rate.
+
+      <details>
+        <summary>
+          <strong>bookingWindow</strong> <em>(InventoryDerivedBookingWindow)</em>
+        </summary>
+        Booking Dates for which the rate will be available. Do not send it if you want the rate available for all dates.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(InventoryBookingWindow)</em>
+          </summary>
+          The derived value.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date of the booking window.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date of the booking window.
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>markets</strong> <em>(InventoryDerivedMarkets)</em>
+        </summary>
+        Markets included or excluded. Do not send if the rate is available for all markets. Only informative.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(InventoryMarkets)</em>
+          </summary>
+          The derived value.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>included</strong> <em>(String)</em>
+            </summary>
+            Included markets.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>excluded</strong> <em>(String)</em>
+            </summary>
+            Excluded markets.
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>rateRule</strong> <em>(InventoryDerivedRateRule)</em>
+        </summary>
+        Rate rule for the derived rate.
+
+        <details open>
+          <summary>
+            <strong>value</strong> <em>(RatePlanType)</em>
+          </summary>
+          The derived value.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_RATE_PLAN_TYPE</code></li>
+            <li><code>LARGE_FAMILY</code></li>
+            <li><code>PUBLIC_SERVANT</code></li>
+            <li><code>NEGOTIATED</code></li>
+            <li><code>PACKAGE</code></li>
+            <li><code>CANARY_RESIDENT</code></li>
+            <li><code>BALEARIC_RESIDENT</code></li>
+            <li><code>HONEY_MOON</code></li>
+          </ul>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>seniorRule</strong> <em>(InventoryDerivedSeniorRule)</em>
+        </summary>
+        Senior rule for the derived rate.
+
+        <details open>
+          <summary>
+            <strong>value</strong> <em>(SeniorRate)</em>
+          </summary>
+          The derived value.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_SENIOR_RATE</code></li>
+            <li><code>SENIOR_RATE_55</code></li>
+            <li><code>SENIOR_RATE_60</code></li>
+            <li><code>SENIOR_RATE_65</code></li>
+          </ul>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>cancelPolicies</strong> <em>(InventoryDerivedCancelPoliciesRate)</em>
+      </summary>
+      Cancel policies associated with the derived rate.
+
+      <details>
+        <summary>
+          <strong>value</strong> <em>(InventoryCancelPoliciesRate)</em>
+        </summary>
+        The derived value.
+
+        <details>
+          <summary>
+            <strong>baseCancelPolicy</strong> <em>(InventoryCancelPolicy)</em>
+          </summary>
+          Defines the base cancel policies. Only Informative.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+            </summary>
+            Indicates if the rate is refundable.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPenalties</strong> <em>(InventoryCancelPenalty)</em>
+            </summary>
+            List of penalties applicable for the rate. See CancelPenalty.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+              </summary>
+              Number of days prior to arrival day in which this Cancellation policy applies.
+            </details>
+
+            <details open>
+              <summary>
+                <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+              </summary>
+              Penalty type. See PenaltyType.
+              <strong>Possible values:</strong>
+              <ul>
+                <li><code>AMOUNT</code></li>
+                <li><code>NIGHTS</code></li>
+                <li><code>PERCENTAGE</code></li>
+              </ul>
+            </details>
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+              </summary>
+              Penalty value.
+            </details>
+          </details>
+        </details>
+
+        <details>
+          <summary>
+            <strong>cancelPoliciesByDate</strong> <em>(InventoryCancelPolicyByDate)</em>
+          </summary>
+          This defines a calendar of cancel policies, serving as informational data. If base cancel policies exist for a particular day, the CancelPoliciesByDate take precedence.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date where the cancel policy must apply.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date where the cancel policy must apply.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPolicy</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryCancelPolicy)</em>
+            </summary>
+            Cancel policy. See CancelPolicy.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+              </summary>
+              Indicates if the rate is refundable.
+            </details>
+
+            <details>
+              <summary>
+                <strong>cancelPenalties</strong> <em>(InventoryCancelPenalty)</em>
+              </summary>
+              List of penalties applicable for the rate. See CancelPenalty.
+
+              <details style={{ pointerEvents: "none" }}>
+                <summary>
+                  <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+                </summary>
+                Number of days prior to arrival day in which this Cancellation policy applies.
+              </details>
+
+              <details open>
+                <summary>
+                  <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+                </summary>
+                Penalty type. See PenaltyType.
+                <strong>Possible values:</strong>
+                <ul>
+                  <li><code>AMOUNT</code></li>
+                  <li><code>NIGHTS</code></li>
+                  <li><code>PERCENTAGE</code></li>
+                </ul>
+              </details>
+
+              <details style={{ pointerEvents: "none" }}>
+                <summary>
+                  <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+                </summary>
+                Penalty value.
+              </details>
+            </details>
+          </details>
+        </details>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the value is inherited from the base rate.
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>inheritedSurcharges</strong> <em>(InventorySurcharge)</em>
+      </summary>
+      Surcharges inherited from the base rate.
+
+      <details open>
+        <summary>
+          <strong>chargeType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryChargeType)</em>
+        </summary>
+        Indicates if the surcharge is included or not in the price.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>INCLUDED</code></li>
+          <li><code>EXCLUDED</code></li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>
+          <strong>taxType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryTaxType)</em>
+        </summary>
+        The type of tax applied to the surcharge.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>CITY</code>: The tax is a city tax.</li>
+          <li><code>LOCAL</code>: The tax is a local tax.</li>
+          <li><code>RESORT_FEE</code>: The tax is a resort fee.</li>
+          <li><code>SUPPLEMENT_TO_BE_PAID_ON_SPOT</code>: The tax is a supplement to be paid on spot.</li>
+        </ul>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+        </summary>
+        The value of the surcharge.
+      </details>
+
+      <details open>
+        <summary>
+          <strong>applyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryApplyType)</em>
+        </summary>
+        The type of application for the surcharge.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>PERCENTAGE</code>: The rate is applied as a percentage.</li>
+          <li><code>AMOUNT</code>: The rate is applied as an amount.</li>
+        </ul>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>perNight</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the surcharge is applied per night.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>perPax</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the surcharge is applied per person.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritAllRoomsBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether all rooms are inherited from the base rate for the derived rate.
+      If true, all rooms from the base rate are inherited. If false, only specific rooms are associated with the derived rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>rooms</strong> <em>(InventoryRoomSetUp)</em>
+      </summary>
+      Rooms associated with the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>code</strong> <em>(String)</em>
+        </summary>
+        Code associated with the room.
+      </details>
+
+      <details>
+        <summary>
+          <strong>master</strong> <em>(InventoryMasterRoom)</em>
+        </summary>
+        Master of the room.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>id</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Id associated with the room master.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>code</strong> <em>(String)</em>
+          </summary>
+          Code associated with the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>name</strong> <em>(String)</em>
+          </summary>
+          Name associated with the room.
+        </details>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>active</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the room is active.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>externalCode</strong> <em>(String)</em>
+        </summary>
+        External code associated with the room.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>standard</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Standard of the room. Typically the number of guests.
+      </details>
+
+      <details>
+        <summary>
+          <strong>uses</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryRoomUse)</em>
+        </summary>
+        List of uses associated with the room.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>numberOfGuests</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the number of guests allowed in the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>minAge</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the minimum age allowed for guests in the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>maxAge</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the maximum age allowed for guests in the room.
+        </details>
+
+        <details open>
+          <summary>
+            <strong>paxType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryPaxType)</em>
+          </summary>
+          Gets or sets the type of guests allowed in the room.
+          PaxType
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>INFANT</code>: Represents an infant guest.</li>
+            <li><code>CHILD</code>: Represents a child guest.</li>
+            <li><code>ADULT</code>: Represents an adult guest.</li>
+          </ul>
+        </details>
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>informBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates if the base rate code has to be sent to the supplier instead of the derived rate code.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritMealPlanSupplements</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether to inherit meal plan supplements from the base rate.
+    </details>
+  </details>
+
+  <details>
+    <summary>
+      <strong>ratesUpdated</strong> <em>(DerivedRateSetup)</em>
+    </summary>
+    Collection of updated derived rate setup objects.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>code</strong> <em>(String)</em>
+      </summary>
+      Code associated with the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>name</strong> <em>(String)</em>
+      </summary>
+      Name of the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>active</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether the derived rate is active.
+    </details>
+
+    <details>
+      <summary>
+        <strong>mealPlanIncluded</strong> <em>(InventoryDerivedInt)</em>
+      </summary>
+      Indicates the meal plan included in the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>value</strong> <em>(Int)</em>
+        </summary>
+        The derived value.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the value is inherited from the base rate.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>baseCode</strong> <em>(String)</em>
+      </summary>
+      Base rate code associated with the derived rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>inheritedAgePolicies</strong> <em>(InventoryAgePolicies)</em>
+      </summary>
+      Age policies inherited from the base rate. Age policies are always inherited from the base rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>maxAgeInfants</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Max age baby not inclusive
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>freeInfants</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        If true the babies are free of charge
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>maxAgeChildren</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Max age child not inclusive
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>freeChildren</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        If true children are free of charge
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>paymentPolicies</strong> <em>(InventoryDerivedPaymentPolicies)</em>
+      </summary>
+      Payment policies associated with the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedCurrency</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Currency)</em>
+        </summary>
+        Currency inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedCommission</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+        </summary>
+        Commission inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritedPriceIsBinding</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the inherited prices are binding.
+      </details>
+
+      <details>
+        <summary>
+          <strong>acceptedPayments</strong> <em>(InventoryDerivedAcceptedPayments)</em>
+        </summary>
+        Accepted payment methods with inheritance metadata.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(AcceptedPayment)</em>
+          </summary>
+          The derived value.
+
+          <details open>
+            <summary>
+              <strong>type</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PaymentType)</em>
+            </summary>
+
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>MERCHANT</code>: Payment is managed by the supplier.</li>
+              <li><code>DIRECT</code>: Payment is made directly to the actual payee (e.g., the hotel), without involving an intermediary or third party. The payment will be completed at check-in.</li>
+              <li><code>CARD_BOOKING</code>: Payment is managed by the supplier. The payment is effectuated at the time of booking.</li>
+              <li><code>CARD_CHECK_IN</code>: Payment is managed by the supplier and is made at the hotel during check-in.</li>
+            </ul>
+          </details>
+
+          <details open>
+            <summary>
+              <strong>cardTypes</strong> <em>(PaymentCardType)</em>
+            </summary>
+
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>VI</code>: Visa</li>
+              <li><code>AX</code>: American Express</li>
+              <li><code>BC</code>: BC Card</li>
+              <li><code>CA</code>: MasterCard</li>
+              <li><code>CB</code>: Carte Blanche</li>
+              <li><code>CU</code>: China Union Pay</li>
+              <li><code>DS</code>: Discover</li>
+              <li><code>DC</code>: Diners Club</li>
+              <li><code>T</code>: Carta Si</li>
+              <li><code>R</code>: Carte Bleue</li>
+              <li><code>N</code>: Dankort</li>
+              <li><code>L</code>: Delta</li>
+              <li><code>E</code>: Electron</li>
+              <li><code>JC</code>: Japan Credit Bureau</li>
+              <li><code>TO</code>: Maestro</li>
+              <li><code>S</code>: Switch</li>
+              <li><code>EC</code>: Electronic Cash</li>
+              <li><code>EU</code>: EuroCard</li>
+              <li><code>TP</code>: universal air travel card</li>
+              <li><code>OP</code>: optima</li>
+              <li><code>ER</code>: Air Canada/RnRoute</li>
+              <li><code>XS</code>: access</li>
+              <li><code>O</code>: others</li>
+            </ul>
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>bookingRules</strong> <em>(InventoryDerivedBookingRules)</em>
+      </summary>
+      Booking rules associated with the derived rate.
+
+      <details>
+        <summary>
+          <strong>bookingWindow</strong> <em>(InventoryDerivedBookingWindow)</em>
+        </summary>
+        Booking Dates for which the rate will be available. Do not send it if you want the rate available for all dates.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(InventoryBookingWindow)</em>
+          </summary>
+          The derived value.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date of the booking window.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date of the booking window.
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>markets</strong> <em>(InventoryDerivedMarkets)</em>
+        </summary>
+        Markets included or excluded. Do not send if the rate is available for all markets. Only informative.
+
+        <details>
+          <summary>
+            <strong>value</strong> <em>(InventoryMarkets)</em>
+          </summary>
+          The derived value.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>included</strong> <em>(String)</em>
+            </summary>
+            Included markets.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>excluded</strong> <em>(String)</em>
+            </summary>
+            Excluded markets.
+          </details>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>rateRule</strong> <em>(InventoryDerivedRateRule)</em>
+        </summary>
+        Rate rule for the derived rate.
+
+        <details open>
+          <summary>
+            <strong>value</strong> <em>(RatePlanType)</em>
+          </summary>
+          The derived value.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_RATE_PLAN_TYPE</code></li>
+            <li><code>LARGE_FAMILY</code></li>
+            <li><code>PUBLIC_SERVANT</code></li>
+            <li><code>NEGOTIATED</code></li>
+            <li><code>PACKAGE</code></li>
+            <li><code>CANARY_RESIDENT</code></li>
+            <li><code>BALEARIC_RESIDENT</code></li>
+            <li><code>HONEY_MOON</code></li>
+          </ul>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>seniorRule</strong> <em>(InventoryDerivedSeniorRule)</em>
+        </summary>
+        Senior rule for the derived rate.
+
+        <details open>
+          <summary>
+            <strong>value</strong> <em>(SeniorRate)</em>
+          </summary>
+          The derived value.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_SENIOR_RATE</code></li>
+            <li><code>SENIOR_RATE_55</code></li>
+            <li><code>SENIOR_RATE_60</code></li>
+            <li><code>SENIOR_RATE_65</code></li>
+          </ul>
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether the value is inherited from the base rate.
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>cancelPolicies</strong> <em>(InventoryDerivedCancelPoliciesRate)</em>
+      </summary>
+      Cancel policies associated with the derived rate.
+
+      <details>
+        <summary>
+          <strong>value</strong> <em>(InventoryCancelPoliciesRate)</em>
+        </summary>
+        The derived value.
+
+        <details>
+          <summary>
+            <strong>baseCancelPolicy</strong> <em>(InventoryCancelPolicy)</em>
+          </summary>
+          Defines the base cancel policies. Only Informative.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+            </summary>
+            Indicates if the rate is refundable.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPenalties</strong> <em>(InventoryCancelPenalty)</em>
+            </summary>
+            List of penalties applicable for the rate. See CancelPenalty.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+              </summary>
+              Number of days prior to arrival day in which this Cancellation policy applies.
+            </details>
+
+            <details open>
+              <summary>
+                <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+              </summary>
+              Penalty type. See PenaltyType.
+              <strong>Possible values:</strong>
+              <ul>
+                <li><code>AMOUNT</code></li>
+                <li><code>NIGHTS</code></li>
+                <li><code>PERCENTAGE</code></li>
+              </ul>
+            </details>
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+              </summary>
+              Penalty value.
+            </details>
+          </details>
+        </details>
+
+        <details>
+          <summary>
+            <strong>cancelPoliciesByDate</strong> <em>(InventoryCancelPolicyByDate)</em>
+          </summary>
+          This defines a calendar of cancel policies, serving as informational data. If base cancel policies exist for a particular day, the CancelPoliciesByDate take precedence.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date where the cancel policy must apply.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date where the cancel policy must apply.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPolicy</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryCancelPolicy)</em>
+            </summary>
+            Cancel policy. See CancelPolicy.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+              </summary>
+              Indicates if the rate is refundable.
+            </details>
+
+            <details>
+              <summary>
+                <strong>cancelPenalties</strong> <em>(InventoryCancelPenalty)</em>
+              </summary>
+              List of penalties applicable for the rate. See CancelPenalty.
+
+              <details style={{ pointerEvents: "none" }}>
+                <summary>
+                  <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+                </summary>
+                Number of days prior to arrival day in which this Cancellation policy applies.
+              </details>
+
+              <details open>
+                <summary>
+                  <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+                </summary>
+                Penalty type. See PenaltyType.
+                <strong>Possible values:</strong>
+                <ul>
+                  <li><code>AMOUNT</code></li>
+                  <li><code>NIGHTS</code></li>
+                  <li><code>PERCENTAGE</code></li>
+                </ul>
+              </details>
+
+              <details style={{ pointerEvents: "none" }}>
+                <summary>
+                  <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+                </summary>
+                Penalty value.
+              </details>
+            </details>
+          </details>
+        </details>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>isInherit</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the value is inherited from the base rate.
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>inheritedSurcharges</strong> <em>(InventorySurcharge)</em>
+      </summary>
+      Surcharges inherited from the base rate.
+
+      <details open>
+        <summary>
+          <strong>chargeType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryChargeType)</em>
+        </summary>
+        Indicates if the surcharge is included or not in the price.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>INCLUDED</code></li>
+          <li><code>EXCLUDED</code></li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>
+          <strong>taxType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryTaxType)</em>
+        </summary>
+        The type of tax applied to the surcharge.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>CITY</code>: The tax is a city tax.</li>
+          <li><code>LOCAL</code>: The tax is a local tax.</li>
+          <li><code>RESORT_FEE</code>: The tax is a resort fee.</li>
+          <li><code>SUPPLEMENT_TO_BE_PAID_ON_SPOT</code>: The tax is a supplement to be paid on spot.</li>
+        </ul>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+        </summary>
+        The value of the surcharge.
+      </details>
+
+      <details open>
+        <summary>
+          <strong>applyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryApplyType)</em>
+        </summary>
+        The type of application for the surcharge.
+        <strong>Possible values:</strong>
+        <ul>
+          <li><code>PERCENTAGE</code>: The rate is applied as a percentage.</li>
+          <li><code>AMOUNT</code>: The rate is applied as an amount.</li>
+        </ul>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>perNight</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the surcharge is applied per night.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>perPax</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the surcharge is applied per person.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritAllRoomsBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether all rooms are inherited from the base rate for the derived rate.
+      If true, all rooms from the base rate are inherited. If false, only specific rooms are associated with the derived rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>rooms</strong> <em>(InventoryRoomSetUp)</em>
+      </summary>
+      Rooms associated with the derived rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>code</strong> <em>(String)</em>
+        </summary>
+        Code associated with the room.
+      </details>
+
+      <details>
+        <summary>
+          <strong>master</strong> <em>(InventoryMasterRoom)</em>
+        </summary>
+        Master of the room.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>id</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Id associated with the room master.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>code</strong> <em>(String)</em>
+          </summary>
+          Code associated with the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>name</strong> <em>(String)</em>
+          </summary>
+          Name associated with the room.
+        </details>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>active</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether the room is active.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>externalCode</strong> <em>(String)</em>
+        </summary>
+        External code associated with the room.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>standard</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+        </summary>
+        Standard of the room. Typically the number of guests.
+      </details>
+
+      <details>
+        <summary>
+          <strong>uses</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryRoomUse)</em>
+        </summary>
+        List of uses associated with the room.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>numberOfGuests</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the number of guests allowed in the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>minAge</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the minimum age allowed for guests in the room.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>maxAge</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+          </summary>
+          Gets or sets the maximum age allowed for guests in the room.
+        </details>
+
+        <details open>
+          <summary>
+            <strong>paxType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryPaxType)</em>
+          </summary>
+          Gets or sets the type of guests allowed in the room.
+          PaxType
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>INFANT</code>: Represents an infant guest.</li>
+            <li><code>CHILD</code>: Represents a child guest.</li>
+            <li><code>ADULT</code>: Represents an adult guest.</li>
+          </ul>
+        </details>
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>informBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates if the base rate code has to be sent to the supplier instead of the derived rate code.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritMealPlanSupplements</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether to inherit meal plan supplements from the base rate.
+    </details>
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>ratesDeleted</strong> <em>(String)</em>
+    </summary>
+    Collection of deleted derived rate codes.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>success</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+    </summary>
+    Indicates whether the operation was successful based on the absence of advise messages.
+  </details>
+</details>

--- a/src/graphql/generated-docs/InventoryDerivedRateSetupCreateInput.mdx
+++ b/src/graphql/generated-docs/InventoryDerivedRateSetupCreateInput.mdx
@@ -1,0 +1,463 @@
+
+<details>
+  <summary>
+  **InventoryDerivedRateSetupCreateInput** (*INPUT_OBJECT*)  
+  Derived rate setup create mutation input.  
+  </summary>
+  
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>clientCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Client code.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>supplierCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Travelgate Supplier/Channel code.
+  </details>
+
+  <details>
+    <summary>
+      <strong>rate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryRateDerivedSetupCreateInput)</em>
+    </summary>
+    Derived rate input data.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>code</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+      </summary>
+      Code associated with the rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>name</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+      </summary>
+      Name of the rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>active</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether the rate is active.
+    </details>
+
+    <details>
+      <summary>
+        <strong>mealPlanIncludedDetails</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryDerivedMealPlanIncludedInput)</em>
+      </summary>
+      Indicates whether to inherit the meal plan included from the base rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritMealPlanIncludedFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether to inherit the meal plan included from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>mealPlanIncluded</strong> <em>(Int)</em>
+        </summary>
+        Indicates the meal plan included in the rate.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>informBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates if the base rate code has to be sent to the supplier instead of the derived rate code.
+    </details>
+
+    <details>
+      <summary>
+        <strong>paymentPolicies</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryPaymentPoliciesDerivedInput)</em>
+      </summary>
+      Payment policies associated with the rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether accepted payments are inherited from the base rate.
+      </details>
+
+      <details>
+        <summary>
+          <strong>acceptedPayments</strong> <em>(AcceptedPaymentInput)</em>
+        </summary>
+        Rate Accepted Payments, if not informed it is MerchantPay.
+
+        <details open>
+          <summary>
+            <strong>type</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PaymentType)</em>
+          </summary>
+
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>MERCHANT</code>: Payment is managed by the supplier.</li>
+            <li><code>DIRECT</code>: Payment is made directly to the actual payee (e.g., the hotel), without involving an intermediary or third party. The payment will be completed at check-in.</li>
+            <li><code>CARD_BOOKING</code>: Payment is managed by the supplier. The payment is effectuated at the time of booking.</li>
+            <li><code>CARD_CHECK_IN</code>: Payment is managed by the supplier and is made at the hotel during check-in.</li>
+          </ul>
+        </details>
+
+        <details open>
+          <summary>
+            <strong>cardTypes</strong> <em>(PaymentCardType)</em>
+          </summary>
+
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>VI</code>: Visa</li>
+            <li><code>AX</code>: American Express</li>
+            <li><code>BC</code>: BC Card</li>
+            <li><code>CA</code>: MasterCard</li>
+            <li><code>CB</code>: Carte Blanche</li>
+            <li><code>CU</code>: China Union Pay</li>
+            <li><code>DS</code>: Discover</li>
+            <li><code>DC</code>: Diners Club</li>
+            <li><code>T</code>: Carta Si</li>
+            <li><code>R</code>: Carte Bleue</li>
+            <li><code>N</code>: Dankort</li>
+            <li><code>L</code>: Delta</li>
+            <li><code>E</code>: Electron</li>
+            <li><code>JC</code>: Japan Credit Bureau</li>
+            <li><code>TO</code>: Maestro</li>
+            <li><code>S</code>: Switch</li>
+            <li><code>EC</code>: Electronic Cash</li>
+            <li><code>EU</code>: EuroCard</li>
+            <li><code>TP</code>: universal air travel card</li>
+            <li><code>OP</code>: optima</li>
+            <li><code>ER</code>: Air Canada/RnRoute</li>
+            <li><code>XS</code>: access</li>
+            <li><code>O</code>: others</li>
+          </ul>
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>bookingRules</strong> <em>(InventoryBookingRulesDerivedInput)</em>
+      </summary>
+      Booking rules associated with the rate.
+
+      <details>
+        <summary>
+          <strong>bookingWindowDetails</strong> <em>(InventoryDerivedBookingWindowInput)</em>
+        </summary>
+        Booking window inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritBookingWindowFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether booking dates are inherited from the base rate.
+        </details>
+
+        <details>
+          <summary>
+            <strong>bookingWindow</strong> <em>(InventoryBookingWindowInput)</em>
+          </summary>
+          Booking Dates for which the rate will be available.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date of the booking window.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date of the booking window.
+          </details>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>marketsDetails</strong> <em>(InventoryDerivedMarketsInput)</em>
+        </summary>
+        Markets inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritMarketsFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether markets are inherited from the base rate.
+        </details>
+
+        <details>
+          <summary>
+            <strong>markets</strong> <em>(InventoryMarketsInput)</em>
+          </summary>
+          Markets included or excluded.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>included</strong> <em>(String)</em>
+            </summary>
+            Included markets.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>excluded</strong> <em>(String)</em>
+            </summary>
+            Excluded markets.
+          </details>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>rateRulesDetails</strong> <em>(InventoryDerivedRateRuleInput)</em>
+        </summary>
+        Rate rule inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritRateRuleFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether rate plan types are inherited from the base rate.
+        </details>
+
+        <details open>
+          <summary>
+            <strong>rateRule</strong> <em>(RatePlanType)</em>
+          </summary>
+          Rate plan type.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_RATE_PLAN_TYPE</code></li>
+            <li><code>LARGE_FAMILY</code></li>
+            <li><code>PUBLIC_SERVANT</code></li>
+            <li><code>NEGOTIATED</code></li>
+            <li><code>PACKAGE</code></li>
+            <li><code>CANARY_RESIDENT</code></li>
+            <li><code>BALEARIC_RESIDENT</code></li>
+            <li><code>HONEY_MOON</code></li>
+          </ul>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>seniorRuleDetails</strong> <em>(InventoryDerivedSeniorRuleInput)</em>
+        </summary>
+        Senior rule inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritSeniorRuleFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether senior rates are inherited from the base rate.
+        </details>
+
+        <details open>
+          <summary>
+            <strong>seniorRule</strong> <em>(SeniorRate)</em>
+          </summary>
+          Senior rule.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_SENIOR_RATE</code></li>
+            <li><code>SENIOR_RATE_55</code></li>
+            <li><code>SENIOR_RATE_60</code></li>
+            <li><code>SENIOR_RATE_65</code></li>
+          </ul>
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>cancelPolicies</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryDerivedCancelPoliciesCreateInput)</em>
+      </summary>
+      Cancel policies associated with the rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether cancel policies are inherited from the base rate.
+      </details>
+
+      <details>
+        <summary>
+          <strong>baseCancelPolicy</strong> <em>(InventoryCancelPolicyInput)</em>
+        </summary>
+        Defines the base cancel policies. Only informative.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates if the rate is refundable.
+        </details>
+
+        <details>
+          <summary>
+            <strong>cancelPenalties</strong> <em>(InventoryCancelPenaltyInput)</em>
+          </summary>
+          List of penalties applicable for the rate. See CancelPenalty.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+            </summary>
+            Number of days prior to arrival day in which this Cancellation policy applies.
+          </details>
+
+          <details open>
+            <summary>
+              <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+            </summary>
+            Penalty type. See PenaltyType.
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>AMOUNT</code></li>
+              <li><code>NIGHTS</code></li>
+              <li><code>PERCENTAGE</code></li>
+            </ul>
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+            </summary>
+            Penalty value.
+          </details>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>cancelPoliciesByDate</strong> <em>(InventoryCancelPolicyByDateInput)</em>
+        </summary>
+        Defines a calendar of cancel policies. Only informative.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+          </summary>
+          Start date where the cancel policy must apply.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+          </summary>
+          End date where the cancel policy must apply.
+        </details>
+
+        <details>
+          <summary>
+            <strong>cancelPolicy</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryCancelPolicyInput)</em>
+          </summary>
+          Cancel policy. See CancelPolicy.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+            </summary>
+            Indicates if the rate is refundable.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPenalties</strong> <em>(InventoryCancelPenaltyInput)</em>
+            </summary>
+            List of penalties applicable for the rate. See CancelPenalty.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+              </summary>
+              Number of days prior to arrival day in which this Cancellation policy applies.
+            </details>
+
+            <details open>
+              <summary>
+                <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+              </summary>
+              Penalty type. See PenaltyType.
+              <strong>Possible values:</strong>
+              <ul>
+                <li><code>AMOUNT</code></li>
+                <li><code>NIGHTS</code></li>
+                <li><code>PERCENTAGE</code></li>
+              </ul>
+            </details>
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+              </summary>
+              Penalty value.
+            </details>
+          </details>
+        </details>
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>baseCode</strong> <em>(String)</em>
+      </summary>
+      Base rate code associated with the rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>roomsDetails</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryDerivedRoomsInput)</em>
+      </summary>
+      Room inheritance details associated with the rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritAllRoomsBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether all rooms are inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>rooms</strong> <em>(String)</em>
+        </summary>
+        Rooms associated with the rate when they are not inherited from the base rate.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritMealPlanSupplements</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+      </summary>
+      Indicates whether to inherit meal plan supplements from the base rate.
+    </details>
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>hotelCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Code associated with the hotel.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>contextCode</strong> <em>(String)</em>
+    </summary>
+    Context code.
+  </details>
+  
+</details>

--- a/src/graphql/generated-docs/InventoryDerivedRateSetupDeleteInput.mdx
+++ b/src/graphql/generated-docs/InventoryDerivedRateSetupDeleteInput.mdx
@@ -1,0 +1,43 @@
+
+<details>
+  <summary>
+  **InventoryDerivedRateSetupDeleteInput** (*INPUT_OBJECT*)  
+  Derived rates setup delete input data  
+  </summary>
+  
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>clientCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Client code.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>supplierCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Travelgate Supplier/Channel code.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>derivedRateCodes</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Derived rates codes to delete.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>hotelCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Code associated with the hotel.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>contextCode</strong> <em>(String)</em>
+    </summary>
+    Context code.
+  </details>
+  
+</details>

--- a/src/graphql/generated-docs/InventoryDerivedRateSetupUpdateInput.mdx
+++ b/src/graphql/generated-docs/InventoryDerivedRateSetupUpdateInput.mdx
@@ -1,0 +1,470 @@
+
+<details>
+  <summary>
+  **InventoryDerivedRateSetupUpdateInput** (*INPUT_OBJECT*)  
+  Derived rate setup update mutation input.  
+  </summary>
+  
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>clientCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Client code.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>supplierCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Travelgate Supplier/Channel code.
+  </details>
+
+  <details>
+    <summary>
+      <strong>rate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryRateDerivedSetupUpdateInput)</em>
+    </summary>
+    Derived rate input data.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>code</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+      </summary>
+      Code associated with the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>name</strong> <em>(String)</em>
+      </summary>
+      Name of the derived rate.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>active</strong> <em>(Boolean)</em>
+      </summary>
+      Indicates whether the rate is active.
+    </details>
+
+    <details>
+      <summary>
+        <strong>mealPlanIncludedDetails</strong> <em>(InventoryDerivedMealPlanIncludedInput)</em>
+      </summary>
+      Meal plan inheritance details associated with the rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritMealPlanIncludedFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether to inherit the meal plan included from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>mealPlanIncluded</strong> <em>(Int)</em>
+        </summary>
+        Indicates the meal plan included in the rate.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>informBaseRate</strong> <em>(Boolean)</em>
+      </summary>
+      Indicates if the base rate code has to be sent to the supplier instead of the derived rate code.
+    </details>
+
+    <details>
+      <summary>
+        <strong>paymentPolicies</strong> <em>(InventoryPaymentPoliciesDerivedInput)</em>
+      </summary>
+      Payment policies associated with the rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether accepted payments are inherited from the base rate.
+      </details>
+
+      <details>
+        <summary>
+          <strong>acceptedPayments</strong> <em>(AcceptedPaymentInput)</em>
+        </summary>
+        Rate Accepted Payments, if not informed it is MerchantPay.
+
+        <details open>
+          <summary>
+            <strong>type</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PaymentType)</em>
+          </summary>
+
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>MERCHANT</code>: Payment is managed by the supplier.</li>
+            <li><code>DIRECT</code>: Payment is made directly to the actual payee (e.g., the hotel), without involving an intermediary or third party. The payment will be completed at check-in.</li>
+            <li><code>CARD_BOOKING</code>: Payment is managed by the supplier. The payment is effectuated at the time of booking.</li>
+            <li><code>CARD_CHECK_IN</code>: Payment is managed by the supplier and is made at the hotel during check-in.</li>
+          </ul>
+        </details>
+
+        <details open>
+          <summary>
+            <strong>cardTypes</strong> <em>(PaymentCardType)</em>
+          </summary>
+
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>VI</code>: Visa</li>
+            <li><code>AX</code>: American Express</li>
+            <li><code>BC</code>: BC Card</li>
+            <li><code>CA</code>: MasterCard</li>
+            <li><code>CB</code>: Carte Blanche</li>
+            <li><code>CU</code>: China Union Pay</li>
+            <li><code>DS</code>: Discover</li>
+            <li><code>DC</code>: Diners Club</li>
+            <li><code>T</code>: Carta Si</li>
+            <li><code>R</code>: Carte Bleue</li>
+            <li><code>N</code>: Dankort</li>
+            <li><code>L</code>: Delta</li>
+            <li><code>E</code>: Electron</li>
+            <li><code>JC</code>: Japan Credit Bureau</li>
+            <li><code>TO</code>: Maestro</li>
+            <li><code>S</code>: Switch</li>
+            <li><code>EC</code>: Electronic Cash</li>
+            <li><code>EU</code>: EuroCard</li>
+            <li><code>TP</code>: universal air travel card</li>
+            <li><code>OP</code>: optima</li>
+            <li><code>ER</code>: Air Canada/RnRoute</li>
+            <li><code>XS</code>: access</li>
+            <li><code>O</code>: others</li>
+          </ul>
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>bookingRules</strong> <em>(InventoryBookingRulesDerivedInput)</em>
+      </summary>
+      Booking rules associated with the rate.
+
+      <details>
+        <summary>
+          <strong>bookingWindowDetails</strong> <em>(InventoryDerivedBookingWindowInput)</em>
+        </summary>
+        Booking window inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritBookingWindowFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether booking dates are inherited from the base rate.
+        </details>
+
+        <details>
+          <summary>
+            <strong>bookingWindow</strong> <em>(InventoryBookingWindowInput)</em>
+          </summary>
+          Booking Dates for which the rate will be available.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            Start date of the booking window.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+            </summary>
+            End date of the booking window.
+          </details>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>marketsDetails</strong> <em>(InventoryDerivedMarketsInput)</em>
+        </summary>
+        Markets inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritMarketsFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether markets are inherited from the base rate.
+        </details>
+
+        <details>
+          <summary>
+            <strong>markets</strong> <em>(InventoryMarketsInput)</em>
+          </summary>
+          Markets included or excluded.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>included</strong> <em>(String)</em>
+            </summary>
+            Included markets.
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>excluded</strong> <em>(String)</em>
+            </summary>
+            Excluded markets.
+          </details>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>rateRulesDetails</strong> <em>(InventoryDerivedRateRuleInput)</em>
+        </summary>
+        Rate rule inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritRateRuleFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether rate plan types are inherited from the base rate.
+        </details>
+
+        <details open>
+          <summary>
+            <strong>rateRule</strong> <em>(RatePlanType)</em>
+          </summary>
+          Rate plan type.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_RATE_PLAN_TYPE</code></li>
+            <li><code>LARGE_FAMILY</code></li>
+            <li><code>PUBLIC_SERVANT</code></li>
+            <li><code>NEGOTIATED</code></li>
+            <li><code>PACKAGE</code></li>
+            <li><code>CANARY_RESIDENT</code></li>
+            <li><code>BALEARIC_RESIDENT</code></li>
+            <li><code>HONEY_MOON</code></li>
+          </ul>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>seniorRuleDetails</strong> <em>(InventoryDerivedSeniorRuleInput)</em>
+        </summary>
+        Senior rule inheritance details associated with the rate.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>inheritSeniorRuleFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates whether senior rates are inherited from the base rate.
+        </details>
+
+        <details open>
+          <summary>
+            <strong>seniorRule</strong> <em>(SeniorRate)</em>
+          </summary>
+          Senior rule.
+          <strong>Possible values:</strong>
+          <ul>
+            <li><code>NO_SENIOR_RATE</code></li>
+            <li><code>SENIOR_RATE_55</code></li>
+            <li><code>SENIOR_RATE_60</code></li>
+            <li><code>SENIOR_RATE_65</code></li>
+          </ul>
+        </details>
+      </details>
+    </details>
+
+    <details>
+      <summary>
+        <strong>cancelPolicies</strong> <em>(InventoryDerivedCancelPoliciesUpdateInput)</em>
+      </summary>
+      Cancel policies associated with the rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritFromBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether cancel policies are inherited from the base rate.
+      </details>
+
+      <details>
+        <summary>
+          <strong>baseCancelPolicy</strong> <em>(InventoryCancelPolicyInput)</em>
+        </summary>
+        Defines the base cancel policies. Only informative.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+          </summary>
+          Indicates if the rate is refundable.
+        </details>
+
+        <details>
+          <summary>
+            <strong>cancelPenalties</strong> <em>(InventoryCancelPenaltyInput)</em>
+          </summary>
+          List of penalties applicable for the rate. See CancelPenalty.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+            </summary>
+            Number of days prior to arrival day in which this Cancellation policy applies.
+          </details>
+
+          <details open>
+            <summary>
+              <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+            </summary>
+            Penalty type. See PenaltyType.
+            <strong>Possible values:</strong>
+            <ul>
+              <li><code>AMOUNT</code></li>
+              <li><code>NIGHTS</code></li>
+              <li><code>PERCENTAGE</code></li>
+            </ul>
+          </details>
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+            </summary>
+            Penalty value.
+          </details>
+        </details>
+      </details>
+
+      <details>
+        <summary>
+          <strong>cancelPoliciesByDate</strong> <em>(InventoryCancelPolicyByDateInput)</em>
+        </summary>
+        Defines a calendar of cancel policies. Only informative.
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>start</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+          </summary>
+          Start date where the cancel policy must apply.
+        </details>
+
+        <details style={{ pointerEvents: "none" }}>
+          <summary>
+            <strong>end</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(DateTime)</em>
+          </summary>
+          End date where the cancel policy must apply.
+        </details>
+
+        <details>
+          <summary>
+            <strong>cancelPolicy</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryCancelPolicyInput)</em>
+          </summary>
+          Cancel policy. See CancelPolicy.
+
+          <details style={{ pointerEvents: "none" }}>
+            <summary>
+              <strong>refundable</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+            </summary>
+            Indicates if the rate is refundable.
+          </details>
+
+          <details>
+            <summary>
+              <strong>cancelPenalties</strong> <em>(InventoryCancelPenaltyInput)</em>
+            </summary>
+            List of penalties applicable for the rate. See CancelPenalty.
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>daysBeforeArrival</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Int)</em>
+              </summary>
+              Number of days prior to arrival day in which this Cancellation policy applies.
+            </details>
+
+            <details open>
+              <summary>
+                <strong>penaltyType</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(PenaltyType)</em>
+              </summary>
+              Penalty type. See PenaltyType.
+              <strong>Possible values:</strong>
+              <ul>
+                <li><code>AMOUNT</code></li>
+                <li><code>NIGHTS</code></li>
+                <li><code>PERCENTAGE</code></li>
+              </ul>
+            </details>
+
+            <details style={{ pointerEvents: "none" }}>
+              <summary>
+                <strong>value</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Float)</em>
+              </summary>
+              Penalty value.
+            </details>
+          </details>
+        </details>
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>isPartialUpdate</strong> <em>(Boolean)</em>
+        </summary>
+        Determines whether to add the new policies (true) or replace the existing ones with the new policies (false).
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>baseCode</strong> <em>(String)</em>
+      </summary>
+      Base rate code associated with the rate.
+    </details>
+
+    <details>
+      <summary>
+        <strong>roomsDetails</strong> <em>(InventoryDerivedRoomsInput)</em>
+      </summary>
+      Room inheritance details associated with the rate.
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>inheritAllRoomsBaseRate</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(Boolean)</em>
+        </summary>
+        Indicates whether all rooms are inherited from the base rate.
+      </details>
+
+      <details style={{ pointerEvents: "none" }}>
+        <summary>
+          <strong>rooms</strong> <em>(String)</em>
+        </summary>
+        Rooms associated with the rate when they are not inherited from the base rate.
+      </details>
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>inheritMealPlanSupplements</strong> <em>(Boolean)</em>
+      </summary>
+      Indicates whether to inherit meal plan supplements from the base rate.
+    </details>
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>hotelCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Code associated with the hotel.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>contextCode</strong> <em>(String)</em>
+    </summary>
+    Context code.
+  </details>
+  
+</details>

--- a/src/graphql/generated-docs/InventoryDerivedRatesSetupFilterInput.mdx
+++ b/src/graphql/generated-docs/InventoryDerivedRatesSetupFilterInput.mdx
@@ -1,0 +1,43 @@
+
+<details>
+  <summary>
+  **InventoryDerivedRatesSetupFilterInput** (*INPUT_OBJECT*)  
+  Derived rates setup filter input.  
+  </summary>
+  
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>hotelCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Hotel code of the derived rates to retrieve.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>clientCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Client code.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>supplierCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+    </summary>
+    Travelgate Supplier/Channel code.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>contextCode</strong> <em>(String)</em>
+    </summary>
+    Travelgate Supplier/Channel context code.
+  </details>
+
+  <details style={{ pointerEvents: "none" }}>
+    <summary>
+      <strong>baseRateCodes</strong> <em>(String)</em>
+    </summary>
+    Base rate codes used to filter derived rates.
+  </details>
+  
+</details>

--- a/src/graphql/inventory/set-up/derived-rates-set-up.mutation.js
+++ b/src/graphql/inventory/set-up/derived-rates-set-up.mutation.js
@@ -1,0 +1,175 @@
+export const createDerivedRatesSetUpMutation =
+`mutation ($input: InventoryDerivedRateSetupCreateInput!) {
+  inventory {
+    createDerivedRatesSetup(derivedRateSetupCreateInput: $input) {
+      ratesCreated {
+        code
+        name
+        active
+        baseCode
+        mealPlanIncluded {
+          value
+          isInherit
+        }
+        paymentPolicies {
+          inheritedCurrency
+          inheritedCommission
+          inheritedPriceIsBinding
+          acceptedPayments {
+            value {
+              type
+              cardTypes
+            }
+            isInherit
+          }
+        }
+        inheritAllRoomsBaseRate
+        informBaseRate
+        inheritMealPlanSupplements
+      }
+      success
+      adviseMessages {
+        code
+        description
+        level
+        external {
+          code
+          message
+        }
+      }
+    }
+  }
+}`
+
+export const createDerivedRatesSetUpVariables =
+`{
+  "input": {
+    "clientCode": "CDOC",
+    "supplierCode": "PDOC",
+    "hotelCode": "2",
+    "contextCode": "TGX_PUSH",
+    "rate": {
+      "code": "BAR-DERIVED",
+      "name": "Best Available Rate - Derived",
+      "active": true,
+      "baseCode": "BAR",
+      "mealPlanIncludedDetails": {
+        "inheritMealPlanIncludedFromBaseRate": true
+      },
+      "informBaseRate": false,
+      "paymentPolicies": {
+        "inheritFromBaseRate": true
+      },
+      "bookingRules": {
+        "bookingWindowDetails": {
+          "inheritBookingWindowFromBaseRate": true
+        },
+        "marketsDetails": {
+          "inheritMarketsFromBaseRate": true
+        },
+        "rateRulesDetails": {
+          "inheritRateRuleFromBaseRate": true
+        },
+        "seniorRuleDetails": {
+          "inheritSeniorRuleFromBaseRate": true
+        }
+      },
+      "cancelPolicies": {
+        "inheritFromBaseRate": true
+      },
+      "roomsDetails": {
+        "inheritAllRoomsBaseRate": true
+      },
+      "inheritMealPlanSupplements": true
+    }
+  }
+}`
+
+export const updateDerivedRatesSetUpMutation =
+`mutation ($input: InventoryDerivedRateSetupUpdateInput!) {
+  inventory {
+    updateDerivedRatesSetup(derivedRateSetupUpdateInput: $input) {
+      ratesUpdated {
+        code
+        name
+        active
+        baseCode
+        mealPlanIncluded {
+          value
+          isInherit
+        }
+        informBaseRate
+        inheritMealPlanSupplements
+      }
+      success
+      adviseMessages {
+        code
+        description
+        level
+        external {
+          code
+          message
+        }
+      }
+    }
+  }
+}`
+
+export const updateDerivedRatesSetUpVariables =
+`{
+  "input": {
+    "clientCode": "CDOC",
+    "supplierCode": "PDOC",
+    "hotelCode": "2",
+    "contextCode": "TGX_PUSH",
+    "rate": {
+      "code": "BAR-DERIVED",
+      "name": "Best Available Rate - Derived (updated)",
+      "active": true,
+      "mealPlanIncludedDetails": {
+        "inheritMealPlanIncludedFromBaseRate": false,
+        "mealPlanIncluded": 14
+      },
+      "paymentPolicies": {
+        "inheritFromBaseRate": false,
+        "acceptedPayments": [
+          {
+            "type": "CARD_BOOKING",
+            "cardTypes": ["VI", "CA"]
+          }
+        ]
+      },
+      "inheritMealPlanSupplements": false
+    }
+  }
+}`
+
+export const deleteDerivedRatesSetUpMutation =
+`mutation ($input: InventoryDerivedRateSetupDeleteInput!) {
+  inventory {
+    deleteDerivedRatesSetup(derivedRateSetupDeleteInput: $input) {
+      ratesDeleted
+      success
+      adviseMessages {
+        code
+        description
+        level
+        external {
+          code
+          message
+        }
+      }
+    }
+  }
+}`
+
+export const deleteDerivedRatesSetUpVariables =
+`{
+  "input": {
+    "clientCode": "CDOC",
+    "supplierCode": "PDOC",
+    "hotelCode": "2",
+    "contextCode": "TGX_PUSH",
+    "derivedRateCodes": ["BAR-DERIVED"]
+  }
+}`

--- a/src/graphql/inventory/set-up/derived-rates-set-up.query.js
+++ b/src/graphql/inventory/set-up/derived-rates-set-up.query.js
@@ -1,0 +1,143 @@
+export const derivedRatesSetUpQuery =
+`query ($criteria: InventoryDerivedRatesSetupFilterInput!) {
+  inventory {
+    derivedRatesSetup(derivedRatesSetupFilterInput: $criteria) {
+      rates {
+        code
+        name
+        active
+        baseCode
+        mealPlanIncluded {
+          value
+          isInherit
+        }
+        inheritedAgePolicies {
+          maxAgeChildren
+          maxAgeInfants
+          freeInfants
+          freeChildren
+        }
+        paymentPolicies {
+          inheritedCurrency
+          inheritedCommission
+          inheritedPriceIsBinding
+          acceptedPayments {
+            value {
+              type
+              cardTypes
+            }
+            isInherit
+          }
+        }
+        bookingRules {
+          bookingWindow {
+            value {
+              start
+              end
+            }
+            isInherit
+          }
+          markets {
+            value {
+              included
+              excluded
+            }
+            isInherit
+          }
+          rateRule {
+            value
+            isInherit
+          }
+          seniorRule {
+            value
+            isInherit
+          }
+        }
+        cancelPolicies {
+          value {
+            baseCancelPolicy {
+              refundable
+              cancelPenalties {
+                daysBeforeArrival
+                penaltyType
+                value
+              }
+            }
+            cancelPoliciesByDate {
+              start
+              end
+              cancelPolicy {
+                refundable
+                cancelPenalties {
+                  daysBeforeArrival
+                  penaltyType
+                  value
+                }
+              }
+            }
+          }
+          isInherit
+        }
+        inheritedSurcharges {
+          chargeType
+          taxType
+          value
+          applyType
+          perNight
+          perPax
+        }
+        inheritAllRoomsBaseRate
+        rooms {
+          code
+          master {
+            id
+            code
+            name
+          }
+          active
+          externalCode
+          standard
+          uses {
+            numberOfGuests
+            minAge
+            maxAge
+            paxType
+          }
+        }
+        informBaseRate
+        inheritMealPlanSupplements
+      }
+      success
+      adviseMessages {
+        code
+        description
+        level
+        external {
+          code
+          message
+        }
+      }
+    }
+  }
+}`
+
+export const derivedRatesSetUpVariables =
+`{
+  "criteria": {
+    "clientCode": "CDOC",
+    "supplierCode": "PDOC",
+    "hotelCode": "2",
+    "contextCode": "TGX_PUSH"
+  }
+}`
+
+export const derivedRatesSetUpByBaseCodesVariables =
+`{
+  "criteria": {
+    "clientCode": "CDOC",
+    "supplierCode": "PDOC",
+    "hotelCode": "2",
+    "contextCode": "TGX_PUSH",
+    "baseRateCodes": ["BAR"]
+  }
+}`

--- a/src/graphql/node-map/fileNodeMap.js
+++ b/src/graphql/node-map/fileNodeMap.js
@@ -39,6 +39,11 @@ const FILE_NODE_MAP = {
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rates-set-up/delete-rates-set-up.mdx": ["InventoryRateSetupDeleteInput", "RatesRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rates-set-up/rates-set-up.mdx": ["InventoryRatesSetupFilterInput", "RatesRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rates-set-up/update-rates-set-up.mdx": ["InventoryRatesSetupUpdateInput", "RatesSetUpRs"],
+// **Configuración - Tarifas Derivadas**
+"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx": ["InventoryDerivedRatesSetupFilterInput", "DerivedRatesRs"],
+"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupCreateInput", "DerivedRatesSetupRs"],
+"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupUpdateInput", "DerivedRatesSetupRs"],
+"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupDeleteInput", "DerivedRatesSetupRs"],
 // **Configuración - Habitaciones**
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rooms-set-up/create-rooms-set-up.mdx": ["InventoryRoomsSetupCreateInput", "RoomsSetUpRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rooms-set-up/delete-rooms-set-up.mdx": ["InventoryRoomSetupDeleteInput", "RoomsSetUpRs"],
@@ -78,6 +83,11 @@ const FILE_NODE_MAP = {
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/delete-rates-set-up.mdx": ["InventoryRateSetupDeleteInput", "RatesRs"],
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/rates-set-up.mdx": ["InventoryRatesSetupFilterInput", "RatesRs"],
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rates-set-up/update-rates-set-up.mdx": ["InventoryRateSetupUpdateInput", "RatesSetUpRs"],
+// **Configuración - Tarifas Derivadas**
+"for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx": ["InventoryDerivedRatesSetupFilterInput", "DerivedRatesRs"],
+"for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupCreateInput", "DerivedRatesSetupRs"],
+"for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupUpdateInput", "DerivedRatesSetupRs"],
+"for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupDeleteInput", "DerivedRatesSetupRs"],
 // **Configuración - Habitaciones**
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/create-rooms-set-up.mdx": ["InventoryRoomsSetupCreateInput", "RoomsSetUpRs"],
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/set-up/rooms-set-up/delete-rooms-set-up.mdx": ["InventoryRoomSetupDeleteInput", "RoomsSetUpRs"],

--- a/src/graphql/node-map/fileNodeMap.js
+++ b/src/graphql/node-map/fileNodeMap.js
@@ -40,10 +40,10 @@ const FILE_NODE_MAP = {
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rates-set-up/rates-set-up.mdx": ["InventoryRatesSetupFilterInput", "RatesRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rates-set-up/update-rates-set-up.mdx": ["InventoryRatesSetupUpdateInput", "RatesSetUpRs"],
 // **Configuración - Tarifas Derivadas**
-"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx": ["InventoryDerivedRatesSetupFilterInput", "DerivedRatesRs"],
-"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupCreateInput", "DerivedRatesSetupRs"],
-"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupUpdateInput", "DerivedRatesSetupRs"],
-"for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupDeleteInput", "DerivedRatesSetupRs"],
+"for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/derived-rates-set-up.mdx": ["InventoryDerivedRatesSetupFilterInput", "DerivedRatesRs"],
+"for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/create-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupCreateInput", "DerivedRatesSetupRs"],
+"for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/update-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupUpdateInput", "DerivedRatesSetupRs"],
+"for-sellers/inventory-push-graphql-api/set-up/derived-rates-set-up/delete-derived-rates-set-up.mdx": ["InventoryDerivedRateSetupDeleteInput", "DerivedRatesSetupRs"],
 // **Configuración - Habitaciones**
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rooms-set-up/create-rooms-set-up.mdx": ["InventoryRoomsSetupCreateInput", "RoomsSetUpRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/set-up/rooms-set-up/delete-rooms-set-up.mdx": ["InventoryRoomSetupDeleteInput", "RoomsSetUpRs"],

--- a/src/graphql/scripts/fetchSchema.js
+++ b/src/graphql/scripts/fetchSchema.js
@@ -41,6 +41,12 @@ function resolveAuthHeader() {
 
 // List of types to extract including all their subtypes
 const REQUIRED_TYPES = new Set([
+  "InventoryDerivedRatesSetupFilterInput",
+  "DerivedRatesRs",
+  "InventoryDerivedRateSetupCreateInput",
+  "InventoryDerivedRateSetupUpdateInput",
+  "InventoryDerivedRateSetupDeleteInput",
+  "DerivedRatesSetupRs",
   "InventoryAvailDerivedRatesInput",
   "AvailDerivedRatesRs",
   "InventoryAvailOffersInput",


### PR DESCRIPTION
Document the Provider v2 Derived Rates Setup operations in the Inventory
Set-Up GraphQL API, mirrored across the for-sellers and for-buyers trees:
- New derived-rates-set-up pages: query (get), create, update and delete.
- New GraphQL query/mutation samples under src/graphql/inventory/set-up.
- Register the new nodes in fileNodeMap.js and REQUIRED_TYPES, and add the
  regenerated <details> breakdown components under generated-docs.

Refs: PUSH-8827