### PR TITLE
docs(inventory): document updateHotelMaster mutation

### DIFF
--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/update-hotel-master.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/update-hotel-master.mdx
@@ -92,7 +92,7 @@ The mutation returns the updated hotel object along with success status and poss
     * `id` (*Int*) - Unique identifier.
     * `name` (*String*) - Hotel name.
     * `email` (*String*) - Contact email.
-    * `phones` (*String*) - Phone numbers.
+    * `phones` (*[String]*) - Phone numbers.
     * `fax` (*String*) - Fax number.
     * `address` (*String*) - Physical address.
     * `postalCode` (*String*) - Postal code.

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/update-hotel-master.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/update-hotel-master.mdx
@@ -60,8 +60,8 @@ To build your `updateHotelMaster` input, identify the hotel to modify through it
 If the hotel belongs to a specific supplier that requires native hotel codes, the field `contextCode` must be provided together with the `hotelCode`. Otherwise the default value "TGX_PUSH" will be used.
 
 :::note
-The `localityId` value from the desired locality can be retrieved using the queries [Localities](../../static-data/localities/) or [Search Localities](../../static-data/localities/search-localities).  
-The possible values for `contextCode` can be retrieved using the query [Inventory Contexts](../../static-data/inventory-contexts).
+The `localityId` value from the desired locality can be retrieved using the queries [Localities](../../static-data/localities/localities.mdx) or [Search Localities](../../static-data/localities/search-localities.mdx).  
+The possible values for `contextCode` can be retrieved using the query [Inventory Contexts](../../static-data/inventory-contexts.mdx).
 :::
 
 ```js

--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/update-hotel-master.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/update-hotel-master.mdx
@@ -1,0 +1,158 @@
+---
+sidebar_position: 4
+---
+import HotelsRs from "../../../../../../../src/graphql/generated-docs/HotelsRs.mdx";
+import InventoryHotelMasterUpdateInput from "../../../../../../../src/graphql/generated-docs/InventoryHotelMasterUpdateInput.mdx";
+
+# Update Hotel Master
+
+## Mutation Overview
+
+The `updateHotelMaster` mutation allows you to update an existing hotel master in Inventory. The returned fields include:
+
+* `id`
+* `name`
+* `email`
+* `phones`
+* `fax`
+* `address`
+* `postalCode`
+* `latitude`
+* `longitude`
+* `externalCode`
+* `category`
+    * `id`
+	* `name`
+* `locality`
+    * `id`
+    * `name`
+    * `countryCode`
+* `hotelCode`
+* `contextCode`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields inside the `hotel` object:
+
+#### Mandatory Input
+* `hotelCode`
+
+#### Optional Input
+* `contextCode`
+* `name`
+* `email`
+* `phones`
+* `fax`
+* `address`
+* `postalCode`
+* `latitude`
+* `longitude`
+* `externalCode`
+* `categoryId`
+* `localityId`
+* `maxAgeBaby`
+* `maxAgeChild`
+
+### 2. Settings
+
+To build your `updateHotelMaster` input, identify the hotel to modify through its `hotelCode` and provide only the fields you want to update. Any field left out will keep its current value.
+
+If the hotel belongs to a specific supplier that requires native hotel codes, the field `contextCode` must be provided together with the `hotelCode`. Otherwise the default value "TGX_PUSH" will be used.
+
+:::note
+The `localityId` value from the desired locality can be retrieved using the queries [Localities](../../static-data/localities/) or [Search Localities](../../static-data/localities/search-localities).  
+The possible values for `contextCode` can be retrieved using the query [Inventory Contexts](../../static-data/inventory-contexts).
+:::
+
+```js
+{
+  "input":{
+    "hotel":{
+      "hotelCode": "1",
+      "contextCode": "TGX_PUSH",
+      "name": "hotel test updated",
+      "email": "hotelpush@xmltravelgate.com",
+      "phones": ["971858585"],
+      "address": "Calle Prueba TEST 2",
+      "postalCode": "07121",
+      "latitude": 50.07,
+      "longitude": 14.14,
+      "localityId": 1042
+    }
+  }
+}
+```
+
+### Response Considerations
+
+The mutation returns the updated hotel object along with success status and possible advise messages.
+
+#### `HotelsRs` (*OBJECT*)
+* `hotels` (*InventoryHotelMaster*) - A collection of updated hotels.
+    * `id` (*Int*) - Unique identifier.
+    * `name` (*String*) - Hotel name.
+    * `email` (*String*) - Contact email.
+    * `phones` (*String*) - Phone numbers.
+    * `fax` (*String*) - Fax number.
+    * `address` (*String*) - Physical address.
+    * `postalCode` (*String*) - Postal code.
+    * `latitude` (*Decimal*) - Geographic latitude.
+    * `longitude` (*Decimal*) - Geographic longitude.
+    * `category` (*InventoryCategory*)
+        * `id` (*Int*) - Category ID.
+        * `name` (*String*) - Category name.
+    * `locality` (*InventoryLocality*)
+        * `id` (*Int*) - Locality ID.
+        * `name` (*String*) - Locality name.
+        * `countryCode` (*String*) - ISO country code.
+    * `hotelCode` (*String*) - Supplier's hotel code.
+    * `contextCode` (*String*) - Context code associated.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+## Mutation Inputs
+
+<InventoryHotelMasterUpdateInput />
+## Returned Fields
+
+<HotelsRs />
+
+
+## Examples
+
+```js
+{
+  "data": {
+    "inventory": {
+      "hotelsMaster": {
+        "hotels": [
+          {
+            "id": 1,
+            "name": "hotel test updated",
+            "hotelCode": "1",
+            "contextCode": "TGX_PUSH",
+            "email": "hotelpush@xmltravelgate.com",
+            "phones": [
+              "971858585"
+            ],
+            "fax": null,
+            "address": "Calle Prueba TEST 2",
+            "postalCode": "07121",
+            "latitude": 50.07,
+            "longitude": 14.14,
+            "category": {
+              "id": 1,
+              "name": "1*"
+            },
+            "locality": {
+              "id": 1042,
+              "name": "Andorra la Vella",
+              "countryCode": "AD"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```

--- a/docs/apis/for-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx
@@ -1,0 +1,159 @@
+---
+sidebar_position: 4
+---
+
+import HotelsRs from "../../../../../../src/graphql/generated-docs/HotelsRs.mdx";
+import InventoryHotelMasterUpdateInput from "../../../../../../src/graphql/generated-docs/InventoryHotelMasterUpdateInput.mdx";
+
+# Update Hotel Master
+
+## Mutation Overview
+
+The `updateHotelMaster` mutation allows you to update an existing hotel master in Inventory. The returned fields include:
+
+* `id`
+* `name`
+* `email`
+* `phones`
+* `fax`
+* `address`
+* `postalCode`
+* `latitude`
+* `longitude`
+* `externalCode`
+* `category`
+    * `id`
+	* `name`
+* `locality`
+    * `id`
+    * `name`
+    * `countryCode`
+* `hotelCode`
+* `contextCode`
+
+### 1. Criteria
+
+When building your mutation, you need to provide the following input fields inside the `hotel` object:
+
+#### Mandatory Input
+* `hotelCode`
+
+#### Optional Input
+* `contextCode`
+* `name`
+* `email`
+* `phones`
+* `fax`
+* `address`
+* `postalCode`
+* `latitude`
+* `longitude`
+* `externalCode`
+* `categoryId`
+* `localityId`
+* `maxAgeBaby`
+* `maxAgeChild`
+
+### 2. Settings
+
+To build your `updateHotelMaster` input, identify the hotel to modify through its `hotelCode` and provide only the fields you want to update. Any field left out will keep its current value.
+
+If the hotel belongs to a specific supplier that requires native hotel codes, the field `contextCode` must be provided together with the `hotelCode`. Otherwise the default value "TGX_PUSH" will be used.
+
+:::note
+The `localityId` value from the desired locality can be retrieved using the queries [Localities](../../static-data/localities/) or [Search Localities](../../static-data/localities/search-localities).  
+The possible values for `contextCode` can be retrieved using the query [Inventory Contexts](../../static-data/inventory-contexts).
+:::
+
+```js
+{
+  "input":{
+    "hotel":{
+      "hotelCode": "1",
+      "contextCode": "TGX_PUSH",
+      "name": "hotel test updated",
+      "email": "hotelpush@xmltravelgate.com",
+      "phones": ["971858585"],
+      "address": "Calle Prueba TEST 2",
+      "postalCode": "07121",
+      "latitude": 50.07,
+      "longitude": 14.14,
+      "localityId": 1042
+    }
+  }
+}
+```
+
+### Response Considerations
+
+The mutation returns the updated hotel object along with success status and possible advise messages.
+
+#### `HotelsRs` (*OBJECT*)
+* `hotels` (*InventoryHotelMaster*) - A collection of updated hotels.
+    * `id` (*Int*) - Unique identifier.
+    * `name` (*String*) - Hotel name.
+    * `email` (*String*) - Contact email.
+    * `phones` (*String*) - Phone numbers.
+    * `fax` (*String*) - Fax number.
+    * `address` (*String*) - Physical address.
+    * `postalCode` (*String*) - Postal code.
+    * `latitude` (*Decimal*) - Geographic latitude.
+    * `longitude` (*Decimal*) - Geographic longitude.
+    * `category` (*InventoryCategory*)
+        * `id` (*Int*) - Category ID.
+        * `name` (*String*) - Category name.
+    * `locality` (*InventoryLocality*)
+        * `id` (*Int*) - Locality ID.
+        * `name` (*String*) - Locality name.
+        * `countryCode` (*String*) - ISO country code.
+    * `hotelCode` (*String*) - Supplier's hotel code.
+    * `contextCode` (*String*) - Context code associated.
+* `success` (*Boolean*) - Indicates if the operation was successful.
+* `adviseMessages` (*AdviseMessage*) - Messages related to the operation.
+
+## Mutation Inputs
+
+<InventoryHotelMasterUpdateInput />
+## Returned Fields
+
+<HotelsRs />
+
+
+## Examples
+
+```js
+{
+  "data": {
+    "inventory": {
+      "hotelsMaster": {
+        "hotels": [
+          {
+            "id": 1,
+            "name": "hotel test updated",
+            "hotelCode": "1",
+            "contextCode": "TGX_PUSH",
+            "email": "hotelpush@xmltravelgate.com",
+            "phones": [
+              "971858585"
+            ],
+            "fax": null,
+            "address": "Calle Prueba TEST 2",
+            "postalCode": "07121",
+            "latitude": 50.07,
+            "longitude": 14.14,
+            "category": {
+              "id": 1,
+              "name": "1*"
+            },
+            "locality": {
+              "id": 1042,
+              "name": "Andorra la Vella",
+              "countryCode": "AD"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```

--- a/docs/apis/for-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx
@@ -93,7 +93,7 @@ The mutation returns the updated hotel object along with success status and poss
     * `id` (*Int*) - Unique identifier.
     * `name` (*String*) - Hotel name.
     * `email` (*String*) - Contact email.
-    * `phones` (*String*) - Phone numbers.
+    * `phones` (*[String]*) - Phone numbers.
     * `fax` (*String*) - Fax number.
     * `address` (*String*) - Physical address.
     * `postalCode` (*String*) - Postal code.

--- a/docs/apis/for-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx
+++ b/docs/apis/for-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx
@@ -61,8 +61,8 @@ To build your `updateHotelMaster` input, identify the hotel to modify through it
 If the hotel belongs to a specific supplier that requires native hotel codes, the field `contextCode` must be provided together with the `hotelCode`. Otherwise the default value "TGX_PUSH" will be used.
 
 :::note
-The `localityId` value from the desired locality can be retrieved using the queries [Localities](../../static-data/localities/) or [Search Localities](../../static-data/localities/search-localities).  
-The possible values for `contextCode` can be retrieved using the query [Inventory Contexts](../../static-data/inventory-contexts).
+The `localityId` value from the desired locality can be retrieved using the queries [Localities](../../static-data/localities/localities.mdx) or [Search Localities](../../static-data/localities/search-localities.mdx).  
+The possible values for `contextCode` can be retrieved using the query [Inventory Contexts](../../static-data/inventory-contexts.mdx).
 :::
 
 ```js

--- a/src/graphql/generated-docs/InventoryHotelMasterUpdateInput.mdx
+++ b/src/graphql/generated-docs/InventoryHotelMasterUpdateInput.mdx
@@ -1,0 +1,120 @@
+
+<details>
+  <summary>
+  **InventoryHotelMasterUpdateInput** (*INPUT_OBJECT*)  
+  Hotel master update mutation input.  
+  </summary>
+  
+  <details>
+    <summary>
+      <strong>hotel</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(InventoryUpdateHotelMasterInput)</em>
+    </summary>
+    Hotel input data.
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>hotelCode</strong>&nbsp;<span class="required"> *</span>&nbsp; <em>(String)</em>
+      </summary>
+      Code of the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>contextCode</strong> <em>(String)</em>
+      </summary>
+      Sets the context code associated with the hotel. If null, TGX_PUSH will be used.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>name</strong> <em>(String)</em>
+      </summary>
+      Name of the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>email</strong> <em>(String)</em>
+      </summary>
+      Email of the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>phones</strong> <em>(String)</em>
+      </summary>
+      List of phone numbers of the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>fax</strong> <em>(String)</em>
+      </summary>
+      Fax number of the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>address</strong> <em>(String)</em>
+      </summary>
+      Address of the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>postalCode</strong> <em>(String)</em>
+      </summary>
+      Postal code of the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>latitude</strong> <em>(Decimal)</em>
+      </summary>
+      Latitude of the hotel location.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>longitude</strong> <em>(Decimal)</em>
+      </summary>
+      Longitude of the hotel location.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>externalCode</strong> <em>(String)</em>
+      </summary>
+      External code associated with the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>categoryId</strong> <em>(Int)</em>
+      </summary>
+      ID of the category associated with the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>localityId</strong> <em>(Int)</em>
+      </summary>
+      ID of the locality associated with the hotel.
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>maxAgeBaby</strong> <em>(Int)</em>
+      </summary>
+      MaxInfantAge
+    </details>
+
+    <details style={{ pointerEvents: "none" }}>
+      <summary>
+        <strong>maxAgeChild</strong> <em>(Int)</em>
+      </summary>
+      MaxChildrenAge
+    </details>
+  </details>
+  
+</details>

--- a/src/graphql/generated-docs/InventoryHotelMasterUpdateInput.mdx
+++ b/src/graphql/generated-docs/InventoryHotelMasterUpdateInput.mdx
@@ -41,7 +41,7 @@
 
     <details style={{ pointerEvents: "none" }}>
       <summary>
-        <strong>phones</strong> <em>(String)</em>
+        <strong>phones</strong> <em>([String])</em>
       </summary>
       List of phone numbers of the hotel.
     </details>

--- a/src/graphql/node-map/fileNodeMap.js
+++ b/src/graphql/node-map/fileNodeMap.js
@@ -4,6 +4,7 @@ const FILE_NODE_MAP = {
     //API GRAPHQL SELLERS
 // **Hoteles**
 "for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/create-hotel-master.mdx": ["InventoryHotelMasterCreateInput", "HotelsRs"],
+"for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx": ["InventoryHotelMasterUpdateInput", "HotelsRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/search-hotels-master.mdx": ["InventoryHotelsMasterSearchFilterInput", "HotelsRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/hotels-master.mdx": ["InventoryHotelMasterFilterInput", "HotelsRs"],
 // **Habitaciones**
@@ -63,6 +64,7 @@ const FILE_NODE_MAP = {
   //API GRAPHQL BUYERS
 // **Hoteles**
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/create-hotel-master.mdx": ["InventoryHotelMasterCreateInput", "HotelsRs"],
+"for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/update-hotel-master.mdx": ["InventoryHotelMasterUpdateInput", "HotelsRs"],
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/hotels-master.mdx": ["InventoryHotelsMasterSearchFilterInput", "HotelsRs"],
 "for-buyers/inventory-buyers/inventory-set-up-graphql-api/masters/hotels-master/search-hotels-master.mdx": ["InventoryHotelMasterFilterInput", "HotelsRs"],
 // **Habitaciones**

--- a/src/graphql/node-map/fileNodeMap.js
+++ b/src/graphql/node-map/fileNodeMap.js
@@ -3,10 +3,10 @@
 const FILE_NODE_MAP = {
     //API GRAPHQL SELLERS
 // **Hoteles**
-"for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/create-hotel-master.mdx": ["InventoryHotelMasterCreateInput", "HotelsRs"],
-"for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx": ["InventoryHotelMasterUpdateInput", "HotelsRs"],
-"for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/search-hotels-master.mdx": ["InventoryHotelsMasterSearchFilterInput", "HotelsRs"],
-"for-sellers/inventory-sellers/inventory-push-graphql-api/masters/hotels-master/hotels-master.mdx": ["InventoryHotelMasterFilterInput", "HotelsRs"],
+"for-sellers/inventory-push-graphql-api/masters/hotels-master/create-hotel-master.mdx": ["InventoryHotelMasterCreateInput", "HotelsRs"],
+"for-sellers/inventory-push-graphql-api/masters/hotels-master/update-hotel-master.mdx": ["InventoryHotelMasterUpdateInput", "HotelsRs"],
+"for-sellers/inventory-push-graphql-api/masters/hotels-master/search-hotels-master.mdx": ["InventoryHotelsMasterSearchFilterInput", "HotelsRs"],
+"for-sellers/inventory-push-graphql-api/masters/hotels-master/hotels-master.mdx": ["InventoryHotelMasterFilterInput", "HotelsRs"],
 // **Habitaciones**
 "for-sellers/inventory-sellers/inventory-push-graphql-api/masters/rooms-master/create-rooms-master.mdx": ["InventoryRoomMasterCreateInput", "RoomsRs"],
 "for-sellers/inventory-sellers/inventory-push-graphql-api/masters/rooms-master/rooms-master.mdx": ["InventoryRoomsMasterFilterInput", "RoomsRs"],


### PR DESCRIPTION
Add Update Hotel Master pages to the for-sellers Inventory Push and the
mirrored for-buyers Inventory Set-Up GraphQL API trees, plus the generated
InventoryHotelMasterUpdateInput breakdown and its fileNodeMap entries.

Refs: PUSH-8812