### PR TITLE
Docs: Update validity of absolute and relative links

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -107,8 +107,9 @@ página …".
 
 ### Conventions the agent follows (quick reference)
 
-- Internal doc links: **relative with `.mdx`** (or `/docs/...` with extension). KB links:
-  **`/kb/...` without extension**, anchors `#lower-kebab-case`.
+- Internal links: use **relative source-file links with `.md`/`.mdx`** for nearby pages, or
+  **absolute `/docs/...` and `/kb/...` routes without extension** for site-route links; anchors
+  `#lower-kebab-case`.
 - Keep the `## Examples` section on generated GraphQL pages.
 - Don't edit JS import identifier lines (`...SetUpMutation`) when fixing prose.
 - Docs prose in **English**; Jira ticket replies in **Spanish**.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,9 +35,9 @@ GraphQL API Reference — not necessarily what the prose currently says.
 ## Invariants (follow exactly on every change)
 
 - **Internal doc links**: relative paths **WITH** the `.mdx`/`.md` extension (e.g.
-  `./availability/rates/load-rate-availability.mdx`); absolute internal links use `/docs/...` **with**
-  extension. Extensionless relative links resolve wrong.
-- **KB links**: absolute `/kb/...` **WITHOUT** extension; anchors as `#lower-kebab-case`.
+  `./availability/rates/load-rate-availability.mdx`). Absolute site routes under `/docs/...` and
+  `/kb/...` are valid **WITHOUT** extension. Extensionless relative links resolve wrong.
+- **KB links**: prefer absolute `/kb/...` **WITHOUT** extension; anchors as `#lower-kebab-case`.
 - Do **not** hardcode `https://docs.travelgate.com/...` for internal pages — use `/docs/...` or relative.
 - `docusaurus.config.js` sets `onBrokenLinks: "throw"` → a broken internal link **fails the build**.
 - Every auto-populated GraphQL page must keep its **`## Examples`** section — `updateDocs.js` inserts

--- a/.github/skills/docs-links/SKILL.md
+++ b/.github/skills/docs-links/SKILL.md
@@ -20,16 +20,18 @@ commit message.
 | Target | Correct form | Example |
 |--------|--------------|---------|
 | Doc → doc, same/nearby tree | **relative path WITH extension** | `[text](./availability/rates/load-rate-availability.mdx)` |
-| Doc → doc, far/absolute | **`/docs/...` WITH extension** | `[text](/docs/apis/for-buyers/hotel-x-pull-buyers-api/quickstart.mdx)` |
+| Doc → doc, far/absolute | **`/docs/...` WITHOUT extension** | `[text](/docs/apis/for-buyers/hotel-x-pull-buyers-api/quickstart)` |
 | Any → KB article | **`/kb/...` WITHOUT extension** | `[text](/kb/welcome-to-travelgate/support-resources/aina-smart-ai)` |
 | Anchor within/other page | append `#lower-kebab-case` | `.../security-overview#fixed-ip-list` |
 | External | full `https://` URL | `[text](https://example.com)` |
 
 Rules of thumb:
-- **Relative and `/docs/` internal links keep the `.mdx`/`.md` extension.** Extensionless relative
-  links resolve wrong. (Exception: KB `/kb/...` links are intentionally extensionless.)
+- **Relative internal links keep the `.mdx`/`.md` extension.** Extensionless relative links resolve
+   wrong.
+- **Absolute `/docs/...` and `/kb/...` site routes are valid without extension.** Prefer relative
+   links for nearby pages and absolute site routes for distant or cross-section links.
 - **Avoid hardcoded `https://docs.travelgate.com/...`** for internal pages — use a site-relative
-  `/docs/...` or a relative `./...mdx` link instead (survives previews, feeds Aina correctly).
+   `/docs/...` or a relative `./...mdx` link instead (survives previews, feeds AIna correctly).
 - Anchors must match a real heading slug on the target page (Docusaurus lowercases, replaces spaces
   with `-`, strips punctuation). Verify the heading exists.
 - `docusaurus.config.js`: `onBrokenLinks: "throw"` (build fails on broken internal links) and
@@ -44,14 +46,14 @@ Rules of thumb:
    Classify each as relative-internal, absolute-internal (`/docs`, `/kb`), external, or anchor-only.
 
 3. **Check conventions:**
-   - Relative or `/docs/` internal link missing `.mdx`/`.md` → flag/fix (add extension).
-   - `/kb/...` link WITH extension → flag/fix (remove extension).
-   - Hardcoded `https://docs.travelgate.com/...` → flag (convert to `/docs/...` keeping the extension,
-     or a relative `./...mdx` if in the same tree).
+    - Relative internal link missing `.mdx`/`.md` → flag/fix (add extension).
+    - Absolute `/docs/...` or `/kb/...` link WITH `.md`/`.mdx` → flag/fix (remove extension).
+    - Hardcoded `https://docs.travelgate.com/...` → flag (convert to `/docs/...` without extension,
+       or a relative `./...mdx` if in the same tree).
 
 4. **Verify targets exist** (this prevents build failures):
    - Relative link → resolve against the file's directory; the target file must exist.
-   - `/docs/<path>.mdx` → maps to `docs/<path>.mdx` (strip leading `/docs/`).
+   - `/docs/<path>` → maps to `docs/<path>.md` or `.mdx` (strip leading `/docs/`).
    - `/kb/<path>` → maps to `kb/<path>.md` or `.mdx` (extensionless in the link).
    - Use the `glob`/`view` tools to confirm each resolved path exists.
 

--- a/.github/skills/docs-maintenance/SKILL.md
+++ b/.github/skills/docs-maintenance/SKILL.md
@@ -41,7 +41,9 @@ use the `graphql-generated-docs` skill for that.
      but singular `updateRateSetup`); casing is `Setup` (lowercase u), not `SetUp`.
 
 4. **Apply the change following repo conventions** (see `.github/copilot-instructions.md`):
-   - Internal links: relative WITH `.mdx`. KB links: absolute `/kb/...` without extension.
+   - Internal links: use relative source-file links WITH `.md`/`.mdx` for nearby pages, or absolute
+     site routes (`/docs/...`, `/kb/...`) WITHOUT extension for cross-section links. Do not use
+     extensionless relative links.
    - Keep the `## Examples` section intact on generated GraphQL pages.
    - Never touch JS import identifier lines (`...SetUpMutation`) when fixing prose.
    - Use admonitions (`:::info`, `:::warning`, `:::tip`) for call-outs.


### PR DESCRIPTION
This pull request updates and clarifies the conventions for internal documentation links across several documentation files. The main focus is to standardize how relative and absolute links are written, especially regarding the inclusion or omission of file extensions for `.md`/`.mdx` files. The changes ensure consistency and prevent broken links by making the rules explicit for both contributors and automation.

**Documentation Link Conventions:**

* Relative internal links must include the `.md`/`.mdx` extension; extensionless relative links are not allowed. [[1]](diffhunk://#diff-f8f6e596a07a083757d8e7554be382a9b6a98d4d7c2c54fa88bb418d05ee670dL23-R34) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L38-R40) [[3]](diffhunk://#diff-2d9c9fabb4723d7c705ece7ccc21748c4e6928b48ee0a42009cef0cbabfa44dbL44-R46)
* Absolute site routes under `/docs/...` and `/kb/...` should be written **without** the file extension (e.g., `/docs/page`, not `/docs/page.mdx`). [[1]](diffhunk://#diff-f8f6e596a07a083757d8e7554be382a9b6a98d4d7c2c54fa88bb418d05ee670dL23-R34) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L38-R40) [[3]](diffhunk://#diff-f8f6e596a07a083757d8e7554be382a9b6a98d4d7c2c54fa88bb418d05ee670dL47-R56)
* KB links must use absolute `/kb/...` routes without the extension, and anchors should use `#lower-kebab-case`. [[1]](diffhunk://#diff-f8f6e596a07a083757d8e7554be382a9b6a98d4d7c2c54fa88bb418d05ee670dL23-R34) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L38-R40) [[3]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L110-R112)

**Automation and Maintenance:**

* The rules for checking and fixing links have been updated: relative links missing extensions are flagged, and absolute `/docs/...` or `/kb/...` links with extensions are flagged for correction (removal of the extension).
* Guidance for contributors has been updated in the relevant skill and instruction files to reflect these conventions. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L110-R112) [[2]](diffhunk://#diff-2d9c9fabb4723d7c705ece7ccc21748c4e6928b48ee0a42009cef0cbabfa44dbL44-R46)