### PR TITLE
Docs: Preserve canonical naming for AIna AI assistant

### DIFF
--- a/.github/agents/docs-maintainer.agent.md
+++ b/.github/agents/docs-maintainer.agent.md
@@ -37,6 +37,8 @@ Load the relevant skill and follow its procedure. Sequence them for multi-part w
 4. **Edit.** Apply the change respecting the invariants. For bulk edits prefer the `edit` tool per
    file; if scripting in PowerShell, `-ne`/`-eq` are case-insensitive (use `-cne`/`-ceq`) and build
    backticks via `[char]0x60`.
+   Preserve canonical product naming in agent-facing text as well: the assistant name is **`AIna`**;
+   only URL paths/slugs are exempt from that casing rule.
 5. **Validate.** `npx docusaurus-mdx-checker`; run `npm run build` for non-trivial link/structure
    changes. Re-`search` to confirm zero stray wrong tokens / all intended files changed.
 6. **Branch.** Cut `docs/push-XXXX-short-slug` from a clean `main`; leave changes **uncommitted**.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Travelgate Public Documentation — Invariants
 
 This repository is the **public Travelgate documentation site** (https://docs.travelgate.com),
-built with **Docusaurus 3** (MDX/Markdown). It is used by external partners and feeds the **Aina**
+built with **Docusaurus 3** (MDX/Markdown). It is used by external partners and feeds the **AIna**
 bot, so accuracy, consistent structure and working links are critical.
 
 These are the rules and facts that must hold for **any** documentation change, regardless of who
@@ -11,12 +11,12 @@ makes it. Behavior/workflow lives in the `Docs Maintainer` agent and the skills 
 ## Repository Map
 
 - `docs/` — main documentation content (`.mdx`). Notable trees:
-  - `docs/apis/for-sellers/inventory-push-graphql-api/**` — Inventory Push GraphQL API (sellers).
-  - `docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/**` — Inventory Set-Up GraphQL API (buyers). **Mirrors the sellers set-up tree** — a change to one usually applies to BOTH.
-  - `docs/apis/for-buyers/hotel-x-pull-buyers-api/**` — Hotel-X Pull API.
-  - `docs/apis/for-buyers/channel-x-push-buyers-api/**` — Channel-X Push API.
+  - `docs/apis/for-sellers/inventory-push-graphql-api/**` — Inventory Push GraphQL API (Sellers).
+  - `docs/apis/for-buyers/inventory-buyers/inventory-set-up-graphql-api/**` — Inventory Set-Up GraphQL API (Buyers). **Mirrors the Sellers set-up tree** — a change to one usually applies to BOTH.
+  - `docs/apis/for-buyers/hotel-x-pull-buyers-api/**` — HotelX Pull API.
+  - `docs/apis/for-buyers/channel-x-push-buyers-api/**` — ChannelX Push API.
   - `docs/apps/inventory/extranet/**` — Inventory Extranet docs.
-- `kb/` — knowledge base articles (`.md`), FAQs, connectivity guides.
+- `kb/` — Knowledge Base articles (`.md`), FAQs, connectivity guides.
 - `api/` — auto-generated **GraphQL API Reference** (do not hand-edit; it is regenerated).
 - `src/graphql/` — GraphQL tooling and the custom "generated-docs" breakdown system.
 
@@ -38,6 +38,9 @@ GraphQL API Reference — not necessarily what the prose currently says.
   `./availability/rates/load-rate-availability.mdx`). Absolute site routes under `/docs/...` and
   `/kb/...` are valid **WITHOUT** extension. Extensionless relative links resolve wrong.
 - **KB links**: prefer absolute `/kb/...` **WITHOUT** extension; anchors as `#lower-kebab-case`.
+- **AIna naming**: when referring to the Travelgate assistant in prose, comments, agent text, or
+  instructions, always write **`AIna`** with capital `A` and `I`. Do **not** normalize URL
+  paths/slugs.
 - Do **not** hardcode `https://docs.travelgate.com/...` for internal pages — use `/docs/...` or relative.
 - `docusaurus.config.js` sets `onBrokenLinks: "throw"` → a broken internal link **fails the build**.
 - Every auto-populated GraphQL page must keep its **`## Examples`** section — `updateDocs.js` inserts


### PR DESCRIPTION
This pull request updates documentation guidelines to enforce consistent and canonical product naming, specifically for the assistant name "AIna", and improves the clarity and accuracy of the repository map. The changes also refine naming conventions for APIs and knowledge base references.

**Product Naming Consistency:**
* Updated all references to the assistant name to use the canonical spelling **`AIna`** (capital "A", capital "I") in prose, comments, and agent-facing text; clarified that URL paths/slugs are exempt from this casing rule (`.github/copilot-instructions.md`, `.github/agents/docs-maintainer.agent.md`). [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R41-R43) [[2]](diffhunk://#diff-4b694d12f1ef713737b3586c16b51de69e6bba1ea6904f240def23e51219c262R40-R41) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L4-R4)

**Repository Map and Naming Improvements:**
* Standardized API and directory names in the repository map for clarity (e.g., "Sellers" and "Buyers" capitalized, "HotelX" and "ChannelX" merged into single words, "Knowledge Base" capitalized) (`.github/copilot-instructions.md`).