### PR TITLE
Docs: Remove Development Roadmap from Documentation

### DIFF
--- a/docs/get-started/connectivity-products.md
+++ b/docs/get-started/connectivity-products.md
@@ -29,7 +29,7 @@ The API mirrors the functionalities of our Inventory Extranet, but with the adde
 
 #### Connectors Pull Sellers Framework
 
-* We have launched a new Pull Sellers API, in which Travelgate currently plays a proactive role in developing API integrations on behalf of the Seller. On this [website](https://app.travelgate.com/network/roadmap) you can find the roadmap and status of developments.
+* [Connectors Pull Sellers Framework](../apis/for-sellers/connectors-pull-developers-api/overview/overview.mdx): This framework supports real-time communication with the Seller's system, allowing dynamic product access for Buyers in the marketplace. It standardizes the integration between Sellers and Travelgate, helping developers build connectors that comply with Travelgate best practices, business rules, and operational standards.
 
 
 #### Inventory Push Sellers API

--- a/kb/connectivity-products/for-sellers/integration-roadmap.md
+++ b/kb/connectivity-products/for-sellers/integration-roadmap.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+draft: true
 ---
 
 # Development Roadmap

--- a/src/theme/Footer/Layout/index.js
+++ b/src/theme/Footer/Layout/index.js
@@ -44,8 +44,8 @@ export default function FooterLayout({style, links, logo, copyright}) {
           <div className="col col--3">
             <h6>Resources</h6>
             <ul>
-              <li><a href="https://docs.travelgate.com/" target="_blank">Documentation</a></li>
-              <li><a href="https://docs.travelgate.com/kb" target="_blank">Help Center</a></li>
+              <li><a href="/" target="_blank">Documentation</a></li>
+              <li><a href="/kb/" target="_blank">Help Center</a></li>
               <li><a href="https://app.travelgate.com/status" target="_blank">Status Services</a></li>
               <li><a href="https://landing.travelgate.com/en/travel-trends-dashboard?utm_campaign=Data%20Digest" target="_blank">Travel Trends Data Dashboard</a></li>
               <li><a href="https://discord.com/servers/travelgate-1121158946074402916" target="_blank">Travelgate Community</a></li>

--- a/src/theme/Footer/Layout/index.js
+++ b/src/theme/Footer/Layout/index.js
@@ -48,7 +48,6 @@ export default function FooterLayout({style, links, logo, copyright}) {
               <li><a href="https://docs.travelgate.com/kb" target="_blank">Help Center</a></li>
               <li><a href="https://app.travelgate.com/status" target="_blank">Status Services</a></li>
               <li><a href="https://landing.travelgate.com/en/travel-trends-dashboard?utm_campaign=Data%20Digest" target="_blank">Travel Trends Data Dashboard</a></li>
-              <li><a href="https://app.travelgate.com/network/roadmap" target="_blank">Integrations Roadmap</a></li>
               <li><a href="https://discord.com/servers/travelgate-1121158946074402916" target="_blank">Travelgate Community</a></li>
               <li><a href="https://www.travelgate.com/press-kit" target="_blank">Press Kit</a></li>
             </ul>


### PR DESCRIPTION
This pull request updates documentation and navigation to improve clarity around the Connectors Pull Sellers Framework and the Integrations Roadmap. The main changes include updating references to the Connectors Pull Sellers Framework, removing a redundant roadmap link from the footer, and marking the integration roadmap documentation as a draft.

**Documentation improvements:**

* Updated the description and link for the Connectors Pull Sellers Framework in `connectivity-products.md` to clarify its purpose and direct users to the new overview documentation.
* Marked the `integration-roadmap.md` documentation as a draft to indicate it's not ready for public consumption.

**Navigation updates:**

* Removed the "Integrations Roadmap" link from the footer to avoid referencing incomplete or draft documentation.