### PR TITLE
Docs: Publish Insights API and hide playground description

### DIFF
--- a/src/components/GraphqlSample.js
+++ b/src/components/GraphqlSample.js
@@ -23,7 +23,7 @@ if (ExecutionEnvironment.canUseDOM) {
     fetcher = null;
 }
 
-const GraphqlSample = ({token, query, variables}) => {
+const GraphqlSample = ({token, query, variables, showLabel = true}) => {
     const isBrowser = useIsBrowser();
     const [headers, setHeaders] = useState(`{
         "Authorization": "Apikey test0000-0000-0000-0000-000000000000"
@@ -49,7 +49,7 @@ const GraphqlSample = ({token, query, variables}) => {
                     {() => {
                         return (
                             <div className="graphql-sample-interactive" aria-label="Interactive GraphQL playground">
-                                <p><strong>Interactive playground:</strong></p>
+                                {showLabel && <p><strong>Interactive playground:</strong></p>}
                                 <GraphiQL
                                     fetcher={fetcher}
                                     initialHeaders={headers}

--- a/src/pages/playground.js
+++ b/src/pages/playground.js
@@ -15,7 +15,7 @@ const Explorer = (props) => {
             description="GraphQL Explorer"
         >
             <div className={`g-playground`}>
-                <GraphqlSample {...props} />
+                <GraphqlSample {...props} showLabel={false} />
             </div>
         </Layout>
     );

--- a/utils/schemaLoader.js
+++ b/utils/schemaLoader.js
@@ -121,7 +121,7 @@ async function loadFilteredSchema() {
         const schema = buildClientSchema(result.data);
 
         // Define which operations to include
-        const allowedQueries = ['hotelX', 'inventory', 'infraestructure', 'stats', 'logging', 'admin'];
+        const allowedQueries = ['hotelX', 'inventory', 'infraestructure', 'stats', 'logging', 'insights', 'admin'];
         const allowedMutations = ['hotelX', 'inventory', 'logging'];
 
         // Build filtered schema string


### PR DESCRIPTION
This pull request introduces a minor UI improvement to the `GraphqlSample` component and expands the allowed queries in the schema loader. The main changes are the addition of a `showLabel` prop to control the display of the "Interactive playground" label and the inclusion of the `insights` query in the allowed queries list.

**UI improvements:**

* Added a `showLabel` prop to the `GraphqlSample` component, allowing consumers to toggle the display of the "Interactive playground" label. The default is `true`. (`src/components/GraphqlSample.js`) [[1]](diffhunk://#diff-27e14a3f0414c20e384a8ea2dec8e1a8e30c9d2c5130998364a21372f35f76cdL26-R26) [[2]](diffhunk://#diff-27e14a3f0414c20e384a8ea2dec8e1a8e30c9d2c5130998364a21372f35f76cdL52-R52)
* Updated the `Explorer` component in `playground.js` to pass `showLabel={false}` to `GraphqlSample`, hiding the label in this context. (`src/pages/playground.js`)

**Schema loader enhancement:**

* Added `insights` to the `allowedQueries` array in `loadFilteredSchema`, enabling this query in the filtered schema. (`utils/schemaLoader.js`)