### PR TITLE
Docs: Fix broken reference in quickstart guide

### DIFF
--- a/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/quickstart.mdx
+++ b/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/quickstart.mdx
@@ -32,7 +32,7 @@ Create your own private copy directly from the **Make my own copy** button in th
 :::
 
 For a complete step-by-step guide on how to use the tool, see:  
-**[📋 Google Sheets CSV Builder](./google-sheets-csv-builder)**
+**[📋 Google Sheets CSV Builder](/docs/apis/for-buyers/inventory-buyers/inventory-set-up-csv-api/google-sheets-csv-builder)**
 
 Alternatively, if you prefer to build CSV files manually, you can follow the formatting rules described in [Section 5 (CSV Format Requirements)](#5-csv-format-requirements) and the field specifications in the individual entity pages.
 


### PR DESCRIPTION
Update the link to the Google Sheets CSV Builder in the quickstart guide to point to the correct documentation path.