### PR TITLE
Docs: Publish connectors error knowledge base

### DIFF
--- a/kb/connectivity-products/for-buyers/errors-and-warnings/connectors-errors.md
+++ b/kb/connectivity-products/for-buyers/errors-and-warnings/connectors-errors.md
@@ -1,43 +1,123 @@
 ---
 sidebar_position: 25
-draft: true
 ---
 
 # Connector Errors
 
-Below is a reference table mapping **Connector error codes** (errors logged during transactions made through our integration when directly interacting with the Seller’s API) to the corresponding error types received in the **Buyer-side API responses** (HotelX/Legacy).  
+When a Buyer request reaches a Seller through a Connector, the Connector trace can contain an
+`AdviseMessage`. The Buyer API response exposes the same situation through a numeric error `type`
+in HotelX or a Legacy error `code`. Use this page to translate Connector messages into the Buyer
+API errors you receive and to identify the supplier details needed for troubleshooting.
 
-This equivalence table helps you quickly identify the cause of an error, enabling you to manage and resolve each case more efficiently.
+## How to Read a Connector Message
 
-## How to Use the Equivalence Table
+Connector messages use these fields:
 
-1. Locate the **Connectors error code** in the first column of the table.
-2. Move across to find the corresponding **Buyer API error code**.
-3. Once you have the Buyer-side error, refer to the [error list documentation](/kb/connectivity-products/for-buyers/errors-and-warnings/overview) for:
-   - A full explanation of the error  
-   - Recommended review steps  
-   - Resolution guidelines
+| Field           | Meaning                                                                 |
+| --------------- | ----------------------------------------------------------------------- |
+| `code`          | The readable Connector message **name**, such as `SupplierTimeout`.         |
+| `id`            | The numeric Connector identifier, such as `31104`.                      |
+| `level`         | `Error`, `Warning`, or `Info`.                                          |
+| `description`   | The standard human-readable explanation.                                |
+| `legacyId`      | The corresponding Legacy error `code` and HotelX error `type`.          |
+| `external`      | Supplier-specific details, when available.                              |
+| `correlationId` | Identifier used to correlate the message with the operation or request. |
 
-:::tip
-Keep this table handy during error troubleshooting to streamline the debugging process across Seller and Buyer APIs💡
+For example, `ItemNotAvailable` has Connector `id` `11301` and maps to Buyer error `301`:
+
+```json
+{
+  "code": "ItemNotAvailable",
+  "description": "Option not found in quote",
+  "id": 11301,
+  "legacyId": 301,
+  "level": "Error",
+  "external": {
+    "httpStatusCode": 200,
+    "message": "Option not found in quote: Parameters not found"
+  }
+}
+```
+
+## Connector-to-Buyer Error Mapping
+
+Use the Connector `legacyId` to find the corresponding Buyer API error. For details and
+resolution steps for a Buyer error, see the [Hotel Buyers API errors and warnings](/kb/connectivity-products/for-buyers/errors-and-warnings/overview).
+
+| Connector `id` | Connector `code`                  | `level`   | `legacyId` | `description`                                          | `external`      |
+| -------------: | --------------------------------- | ------- | ---------------------------------------: | ------------------------------------------------ | ------------- |
+|          11102 | `SupplierError`                   | Error   |                                      102 | Supplier error                                   | Required      |
+|          11207 | `SupplierBadRequest`              | Error   |                                      102 | Bad request to supplier                          | Optional      |
+|          11205 | `SupplierSessionExpired`          | Error   |                                      102 | Supplier session expired                         | Optional      |
+|          11206 | `SupplierResponseNotSerializable` | Error   |                                      102 | Supplier request or response cannot be processed | Optional      |
+|          11304 | `PriceChanged`                    | Error   |                                      102 | Price changed                                    | Optional      |
+|          11305 | `BookingNotFound`                 | Error   |                                      102 | Booking not found                                | Optional      |
+|          12401 | `Unauthorized`                    | Error   |                                      102 | Unauthorized                                     | Optional      |
+|          11204 | `SupplierNoResultsFound`          | Warning |                                      204 | No results found                                 | Optional      |
+|          12207 | `BadRequest`                      | Error   |                                      207 | Request not accepted by supplier                 | Optional      |
+|          12501 | `NotImplemented`                  | Info    |                                      207 | Operation not implemented                        | Not included  |
+|          11301 | `ItemNotAvailable`                | Error   |                                      301 | Option not found in quote                        | Optional      |
+|          11302 | `ItemNotFoundInContent`           | Error   |                                      302 | Hotel not found                                  | Not included  |
+|          11303 | `SupplierBookingNotConfirmed`     | Error   |                                      303 | Booking not confirmed                            | Optional      |
+|          22101 | `InternalError`                   | Error   |                                      101 | Internal error                                   | Optional      |
+|          22105 | `ExtraOperationConnectionError`   | Error   |                                      105 | Internal connection error                        | Not included  |
+|          22106 | `SupplierResponseMaxSizeExceeded` | Error   |                                      105 | Supplier response exceeded the maximum size      | Optional      |
+|          22107 | `MaxOptionsExceeded`              | Error   |                                      101 | Maximum number of options exceeded               | Optional      |
+|          31103 | `SupplierTooManyRequests`         | Error   |                                      103 | Too many requests to the supplier                | Required      |
+|          31104 | `SupplierTimeout`                 | Error   |                                      104 | Connection timeout with supplier                 | Optional      |
+|          31105 | `SupplierConnectionError`         | Error   |                                      105 | Communication error                              | Required      |
+|          12106 | `RequestAbortedByClient`          | Error   |                                      106 | Request aborted by client                        | Not included  |
+|          12290 | `InternalWarning`                 | Warning |                                        0 | Internal warning                                 | Optional      |
+|          11291 | `SupplierWarning`                 | Warning |                                        0 | Supplier warning; check `external` for details   | Required      |
+
+The common Buyer error meanings are:
+
+| Buyer error | Meaning                                                       |
+| ----------: | ------------------------------------------------------------- |
+|           0 | No error code; used for warnings and informational messages.  |
+|         101 | System or internal error                                      |
+|         102 | Provider or supplier error                                    |
+|         103 | Too many requests                                             |
+|         104 | Connection timeout with provider                              |
+|         105 | Communication error                                           |
+|         106 | Request aborted by client                                     |
+|         204 | No results found                                              |
+|         207 | Request not accepted by supplier |
+|         301 | Option not found in quote                                     |
+|         302 | Hotel not found                                               |
+|         303 | Booking not confirmed                                         |
+
+## Supplier Details in `external`
+
+The `external` object contains the supplier context behind a message. It can include:
+
+| Field            | Meaning                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| `code`           | Supplier-specific response or error code (optional). This is not a Connector code.                                      |
+| `message`        | Descriptive, human-readable message returned by, or built from, the supplier response.                                                   |
+| `httpStatusCode` | Supplier HTTP status code, such as `200`, `400`, or `500`; it defaults to `200` when no HTTP status applies. |
+
+```json
+{
+  "code": "E9999.1",
+  "message": "Supplier internal error",
+  "httpStatusCode": 500
+}
+```
+
+## Troubleshooting Connector Errors
+
+1. Find the Connector `legacyId` in the Connector trace and use the mapping table to identify
+   the Buyer error `type` or Legacy `code`.
+2. Read the `description` to understand the standardized result.
+3. For supplier-originated messages, inspect `external.message`, `external.code`, and
+   `external.httpStatusCode`. These fields contain context that may not appear in the standard
+   description.
+4. Use the [Buyer error articles](/kb/connectivity-products/for-buyers/errors-and-warnings/overview) for resolution steps.
+5. Include the `correlationId`, operation, access or connection, timestamp, Connector `id`, and
+   relevant `external` values when contacting [Travelgate Support](https://app.travelgate.com/support).
+
+:::warning
+Do not treat the supplier-specific value in `external.code` as a Connector `code` or `legacyId`. Use the standardized Connector-to-Buyer mapping first, then use `external` to diagnose the
+supplier response.
 :::
-
-| **Connectors error code**                     |   **Connectors Error Name**               |     **Buyer API Error**               |  **Buyer API Error Name**               | 
-| :--------------------------------: |  :------------------------------------: |  :------------------------------------: |   :------------------------------------: | 
-|                  11302    |     ItemNotFoundInContent                                    |               302         |  Hotel Not Found  | 
-|               12207        |             BadRequest                            |  207  |  Request XML Not Accepted by Supplier  | 
-|                  22101     |           InternalError                              |  101 |  System Exception  | 
-|                  11301     |                  ItemNotAvailable                       |  301 |  Option Not Found in Valuation  | 
-|             11207          |                     SupplierBadRequest                    | 102 |  Provider Error  | 
-|                11303       |              SupplierBookingNotConfirmed                           | 303 |  Booking Not Confirmed  | 
-|              31105         |            SupplierConnectionError                             | 105 |  Communication Error  | 
-|                    11102   |                    SupplierError                     | 102 |  Provider Error   | 
-|                  11204     |           SupplierNoResultsFound                              |  204|  No Results Found  | 
-|                     11205  |              SupplierSessionExpired                           | 102 |  Provider Error  | 
-|         31104              |              SupplierTimeout                           |  104|  Connection Timeout With Provider  | 
-|             31103          |         SupplierTooManyRequests                                | 103 |  Too Many Requests to the Supplier  | 
-|      11304                 |                 PriceChanged                        | 102 |  Provider Error  |   
-|          11206             |           SupplierResponseNotSerializable                        | 102 |  Provider Error   |   
-|          12401             |    Unauthorized                                      | 102 |  Provider Error  |    
-|              11305         |           BookingNotFound                                 | 102 |  Provider Error   |     
-|                 22105      |           ExtraOperationConnectionError                          | 105 |  Communication Error   |     


### PR DESCRIPTION
This pull request significantly rewrites the Connector Errors documentation for buyers, making it much clearer and more actionable. The new version explains how Connector errors map to Buyer API errors, provides detailed field descriptions, and introduces comprehensive tables for error translation and troubleshooting. It also clarifies the use of the `external` field for supplier-specific details and offers step-by-step guidance for resolving issues.

**Major improvements and restructuring:**

**1. Documentation clarity and structure:**
- Rewrote the introduction and purpose of the page to focus on translating Connector messages into Buyer API errors and using the mapping for troubleshooting.
- Added clear instructions on how to read Connector messages, including a detailed table explaining each field in the Connector error object.

**2. Error mapping and reference tables:**
- Replaced the previous equivalence table with a new, more comprehensive Connector-to-Buyer error mapping table, including all relevant fields (`id`, `code`, `level`, `legacyId`, `description`, `external`).
- Added a summary table explaining the meaning of common Buyer error codes for quick reference.

**3. Supplier details and troubleshooting:**
- Introduced a new section explaining the `external` object, detailing its fields and their meanings, with examples for supplier-specific error context. 